### PR TITLE
Added data-name attribute to ActionColumn::initDefaultButton()

### DIFF
--- a/src/Columns/ActionColumn.php
+++ b/src/Columns/ActionColumn.php
@@ -184,6 +184,7 @@ class ActionColumn extends Column
                 $options = array_merge([
                     'title'      => $title,
                     'aria-label' => $title,
+                    'data-name'  => $name,
                 ], $additionalOptions, $this->buttonOptions);
                 $icon = Html::tag('span', '', ['class' => "glyphicon glyphicon-$iconName"]);
 


### PR DESCRIPTION
Added `data-name` attribute to the `ActionColumn::initDefaultButton()` function generation.
This helps to programmatically access the buttons

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | -
