### PR TITLE
Update LinkPage and LinkSorter to last UrlGenerator release

### DIFF
--- a/src/BaseListView.php
+++ b/src/BaseListView.php
@@ -47,8 +47,8 @@ abstract class BaseListView extends Widget
     ];
     private int $pageSize = 0;
     private int $currentPage = 1;
-    private array $requestAttributes = [];
-    private array $requestQueryParams = [];
+    private ?array $requestArguments = null;
+    private ?array $requestQueryParams = null;
     private TranslatorInterface $translator;
 
     public function __construct(TranslatorInterface $translator)
@@ -151,12 +151,12 @@ abstract class BaseListView extends Widget
         return $new;
     }
 
-    public function getRequestAttributes(): array
+    public function getRequestArguments(): ?array
     {
-        return $this->requestAttributes;
+        return $this->requestArguments;
     }
 
-    public function getRequestQueryParams(): array
+    public function getRequestQueryParams(): ?array
     {
         return $this->requestQueryParams;
     }
@@ -224,15 +224,15 @@ abstract class BaseListView extends Widget
         return $new;
     }
 
-    public function requestAttributes(array $requestAttributes): self
+    public function requestArguments(?array $requestArguments): self
     {
         $new = clone $this;
-        $new->requestAttributes = $requestAttributes;
+        $new->requestArguments = $requestArguments;
 
         return $new;
     }
 
-    public function requestQueryParams(array $requestQueryParams): self
+    public function requestQueryParams(?array $requestQueryParams): self
     {
         $new = clone $this;
         $new->requestQueryParams = $requestQueryParams;
@@ -415,7 +415,7 @@ abstract class BaseListView extends Widget
         return LinkPager::widget()
             ->paginator($this->paginator)
             ->cssFramework($this->cssFramework)
-            ->requestAttributes($this->requestAttributes)
+            ->requestArguments($this->requestArguments)
             ->requestQueryParams($this->requestQueryParams)
             ->render();
     }

--- a/src/Columns/DataColumn.php
+++ b/src/Columns/DataColumn.php
@@ -274,7 +274,7 @@ final class DataColumn extends Column
                 ->currentPage($this->grid->getPaginator()->getCurrentPage())
                 ->cssFramework($this->grid->getCssFramework())
                 ->options(array_merge($this->sortLinkOptions, ['label' => $label]))
-                ->requestAttributes($this->grid->getRequestAttributes())
+                ->requestArguments($this->grid->getRequestArguments())
                 ->requestQueryParams($this->grid->getRequestQueryParams())
                 ->sort($sort)
                 ->render();

--- a/src/Widget/LinkPager.php
+++ b/src/Widget/LinkPager.php
@@ -78,7 +78,7 @@ final class LinkPager extends Widget
     private bool $hideOnSinglePage = false;
     private int $maxButtonCount = 10;
     private bool $registerLinkTags = false;
-    private ?array $requestAttributes = null;
+    private ?array $requestArguments = null;
     private ?array $requestQueryParams = null;
     private string $pageParam = 'page';
     private CurrentRoute $currentRoute;
@@ -102,8 +102,8 @@ final class LinkPager extends Widget
             throw new InvalidConfigException('The "paginator" property must be set.');
         }
 
-        if ($this->requestAttributes === null) {
-            $this->requestAttributes = $this->currentRoute->getArguments();
+        if ($this->requestArguments === null) {
+            $this->requestArguments = $this->currentRoute->getArguments();
         }
 
         if ($this->requestQueryParams === null) {
@@ -138,6 +138,22 @@ final class LinkPager extends Widget
     }
 
     /**
+     * Set option for widget
+     *
+     * @param string $name
+     * @param mixed $value
+     *
+     * @return self
+     */
+    private function setOption(string $name, $value): self
+    {
+        $new = clone $this;
+        $new->{$name} = $value;
+
+        return $new;
+    }
+
+    /**
      * Name of $_GET page param using for pagination
      *
      * @param string $value
@@ -146,10 +162,7 @@ final class LinkPager extends Widget
      */
     public function pageParam(string $value): self
     {
-        $new = clone $this;
-        $new->pageParam = $value;
-
-        return $new;
+        return $this->setOption('pageParam', $value);
     }
 
     /**
@@ -159,10 +172,7 @@ final class LinkPager extends Widget
      */
     public function buttonsContainerAttributes(array $buttonsContainerAttributes): self
     {
-        $new = clone $this;
-        $new->buttonsContainerAttributes = $buttonsContainerAttributes;
-
-        return $new;
+        return $this->setOption('buttonsContainerAttributes', $buttonsContainerAttributes);
     }
 
     /**
@@ -172,10 +182,7 @@ final class LinkPager extends Widget
      */
     public function activeButtonAttributes(array $attributes): self
     {
-        $new = clone $this;
-        $new->activeButtonAttributes = $attributes;
-
-        return $new;
+        return $this->setOption('activeButtonAttributes', $attributes);
     }
 
     /**
@@ -185,10 +192,7 @@ final class LinkPager extends Widget
      */
     public function disabledButtonAttributes(array $attributes): self
     {
-        $new = clone $this;
-        $new->disabledButtonAttributes = $attributes;
-
-        return $new;
+        return $this->setOption('disabledButtonAttributes', $attributes);
     }
 
     /**
@@ -198,10 +202,7 @@ final class LinkPager extends Widget
      */
     public function firstPageAttributes(array $attributes): self
     {
-        $new = clone $this;
-        $new->firstPageAttributes = $attributes;
-
-        return $new;
+        return $this->setOption('firstPageAttributes', $attributes);
     }
 
     /**
@@ -211,10 +212,7 @@ final class LinkPager extends Widget
      */
     public function firstPageLabel(?string $label): self
     {
-        $new = clone $this;
-        $new->firstPageLabel = $label;
-
-        return $new;
+        return $this->setOption('firstPageLabel', $label);
     }
 
     /**
@@ -224,10 +222,7 @@ final class LinkPager extends Widget
      */
     public function lastPageAttributes(array $attributes): self
     {
-        $new = clone $this;
-        $new->lastPageAttributes = $attributes;
-
-        return $new;
+        return $this->setOption('lastPageAttributes', $attributes);
     }
 
     /**
@@ -238,10 +233,7 @@ final class LinkPager extends Widget
      */
     public function lastPageLabel(?string $label): self
     {
-        $new = clone $this;
-        $new->lastPageLabel = $label;
-
-        return $new;
+        return $this->setOption('lastPageLabel', $label);
     }
 
     /**
@@ -251,10 +243,7 @@ final class LinkPager extends Widget
      */
     public function disableCurrentPageButton(bool $disableCurrentPageButton = true): self
     {
-        $new = clone $this;
-        $new->disableCurrentPageButton = $disableCurrentPageButton;
-
-        return $new;
+        return $this->setOption('disableCurrentPageButton', $disableCurrentPageButton);
     }
 
     public function cssFramework(string $cssFramework): self
@@ -264,10 +253,7 @@ final class LinkPager extends Widget
             throw new InvalidConfigException("Invalid CSS framework. Valid values are: \"$cssFramework\".");
         }
 
-        $new = clone $this;
-        $new->cssFramework = $cssFramework;
-
-        return $new;
+        return $this->setOption('cssFramework', $cssFramework);
     }
 
     /**
@@ -277,10 +263,7 @@ final class LinkPager extends Widget
      */
     public function hideOnSinglePage(bool $hideOnSinglePage = true): self
     {
-        $new = clone $this;
-        $new->hideOnSinglePage = $hideOnSinglePage;
-
-        return $new;
+        return $this->setOption('hideOnSinglePage', $hideOnSinglePage);
     }
 
     /**
@@ -292,10 +275,7 @@ final class LinkPager extends Widget
      */
     public function linkAttributes(array $linkAttributes): self
     {
-        $new = clone $this;
-        $new->linkAttributes = $linkAttributes;
-
-        return $new;
+        return $this->setOption('linkAttributes', $linkAttributes);
     }
 
     /**
@@ -305,10 +285,7 @@ final class LinkPager extends Widget
      */
     public function activeLinkAttributes(array $attributes): self
     {
-        $new = clone $this;
-        $new->activeLinkAttributes = $attributes;
-
-        return $new;
+        return $this->setOption('activeLinkAttributes', $attributes);
     }
 
     /**
@@ -318,10 +295,7 @@ final class LinkPager extends Widget
      */
     public function disabledLinkAttributes(array $attributes): self
     {
-        $new = clone $this;
-        $new->disabledLinkAttributes = $attributes;
-
-        return $new;
+        return $this->setOption('disabledLinkAttributes', $attributes);
     }
 
     /**
@@ -331,10 +305,7 @@ final class LinkPager extends Widget
      */
     public function maxButtonCount(int $maxButtonCount): self
     {
-        $new = clone $this;
-        $new->maxButtonCount = $maxButtonCount;
-
-        return $new;
+        return $this->setOption('maxButtonCount', $maxButtonCount);
     }
 
     /**
@@ -344,10 +315,7 @@ final class LinkPager extends Widget
      */
     public function nextPageAttributes(array $attributes): self
     {
-        $new = clone $this;
-        $new->nextPageAttributes = $attributes;
-
-        return $new;
+        return $this->setOption('nextPageAttributes', $attributes);
     }
 
     /**
@@ -357,10 +325,7 @@ final class LinkPager extends Widget
      */
     public function nextPageLabel(?string $label): self
     {
-        $new = clone $this;
-        $new->nextPageLabel = $label;
-
-        return $new;
+        return $this->setOption('nextPageLabel', $label);
     }
 
     /**
@@ -372,10 +337,7 @@ final class LinkPager extends Widget
      */
     public function navAttributes(array $navAttributes): self
     {
-        $new = clone $this;
-        $new->navAttributes = $navAttributes;
-
-        return $new;
+        return $this->setOption('navAttributes', $navAttributes);
     }
 
     /**
@@ -387,10 +349,7 @@ final class LinkPager extends Widget
      */
     public function ulAttributes(array $ulAttributes): self
     {
-        $new = clone $this;
-        $new->ulAttributes = $ulAttributes;
-
-        return $new;
+        return $this->setOption('ulAttributes', $ulAttributes);
     }
 
     /**
@@ -400,10 +359,7 @@ final class LinkPager extends Widget
      */
     public function paginator(OffsetPaginator $paginator): self
     {
-        $new = clone $this;
-        $new->paginator = $paginator;
-
-        return $new;
+        return $this->setOption('paginator', $paginator);
     }
 
     /**
@@ -413,10 +369,7 @@ final class LinkPager extends Widget
      */
     public function prevPageAttributes(array $attributes): self
     {
-        $new = clone $this;
-        $new->prevPageAttributes = $attributes;
-
-        return $new;
+        return $this->setOption('prevPageAttributes', $attributes);
     }
 
     /**
@@ -426,26 +379,17 @@ final class LinkPager extends Widget
      */
     public function prevPageLabel(?string $label): self
     {
-        $new = clone $this;
-        $new->prevPageLabel = $label;
-
-        return $new;
+        return $this->setOption('prevPageLabel', $label);
     }
 
-    public function requestAttributes(?array $requestAttributes): self
+    public function requestArguments(?array $requestArguments): self
     {
-        $new = clone $this;
-        $new->requestAttributes = $requestAttributes;
-
-        return $new;
+        return $this->setOption('requestArguments', $requestArguments);
     }
 
     public function requestQueryParams(?array $requestQueryParams): self
     {
-        $new = clone $this;
-        $new->requestQueryParams = $requestQueryParams;
-
-        return $new;
+        return $this->setOption('requestQueryParams', $requestQueryParams);
     }
 
     /**
@@ -461,10 +405,7 @@ final class LinkPager extends Widget
      */
     public function registerLinkTags(bool $registerLinkTags = true): self
     {
-        $new = clone $this;
-        $new->registerLinkTags = $registerLinkTags;
-
-        return $new;
+        return $this->setOption('registerLinkTags', $registerLinkTags);
     }
 
     /**
@@ -530,27 +471,23 @@ final class LinkPager extends Widget
         $tag = ArrayHelper::remove($this->ulAttributes, 'tag', 'ul');
 
         $html =
-            Html::openTag('nav', $this->navAttributes) . "\n" .
+            Html::openTag('nav', $this->navAttributes) .
                 Html::tag(
                     $tag,
-                    "\n" .
                     $renderFirstPageButtonLink . $renderPreviousPageButtonLink .
-                    "\n" .
-                    implode("\n", $renderPageButtonLinks) .
-                    "\n" .
-                    $renderNextPageButtonLink . $renderLastPageButtonLink .
-                    "\n",
+                    implode('', $renderPageButtonLinks) .
+                    $renderNextPageButtonLink . $renderLastPageButtonLink,
                     $this->ulAttributes
-                )->encode(false) . "\n" .
+                )->encode(false) .
             Html::closeTag('nav');
 
         if ($this->cssFramework === self::BULMA) {
             $html =
-                Html::openTag('nav', $this->navAttributes) . "\n" .
+                Html::openTag('nav', $this->navAttributes) .
                     trim($renderFirstPageButtonLink) . trim($renderPreviousPageButtonLink) .
-                    Html::tag($tag, "\n" . implode("\n", $renderPageButtonLinks), $this->ulAttributes)->encode(false) .
-                    trim($renderNextPageButtonLink) . trim($renderLastPageButtonLink) . "\n" .
-                Html::closeTag('nav') . "\n";
+                    Html::tag($tag, implode('', $renderPageButtonLinks), $this->ulAttributes)->encode(false) .
+                    trim($renderNextPageButtonLink) . trim($renderLastPageButtonLink) .
+                Html::closeTag('nav');
         }
 
         return $html;
@@ -596,7 +533,7 @@ final class LinkPager extends Widget
             }
         }
 
-        $encode = is_numeric($label) ? false : ArrayHelper::remove($buttonsAttributes, 'encode', true);
+        $encode = is_numeric($label) ? null : (bool) ArrayHelper::remove($buttonsAttributes, 'encode', true);
 
         return Html::tag(
             $linkWrapTag,
@@ -642,14 +579,14 @@ final class LinkPager extends Widget
      */
     private function createUrl(int $page): string
     {
-        $params = array_merge($this->requestAttributes, $this->requestQueryParams, [$this->pageParam => $page]);
+        $queryParameters = array_merge($this->requestQueryParams, [$this->pageParam => $page]);
 
         if ($name = $this->currentRoute->getName()) {
-            return $this->urlGenerator->generate($name, $params);
+            return $this->urlGenerator->generate($name, $this->requestArguments, $queryParameters);
         }
 
-        if (count($params) > 1) {
-            return '?' . http_build_query($params);
+        if (count($queryParameters) > 1) {
+            return '?' . http_build_query($queryParameters);
         }
 
         return '';

--- a/src/Widget/LinkPager.php
+++ b/src/Widget/LinkPager.php
@@ -43,21 +43,36 @@ final class LinkPager extends Widget
         self::BOOTSTRAP,
         self::BULMA,
     ];
-    private array $buttonsContainerAttributes = [];
-    private array $linkAttributes = ['class' => 'page-link'];
+    private array $buttonsContainerAttributes = [
+        'class' => 'page-item',
+    ];
+    private array $activeButtonAttributes = [
+        'class' => 'active',
+    ];
+    private array $disabledButtonAttributes = [
+        'class' => 'disabled',
+    ];
+    private array $linkAttributes = [
+        'class' => 'page-link',
+   ];
+    private array $activeLinkAttributes = [];
+    private array $disabledLinkAttributes = [];
     private array $navAttributes = ['aria-label' => 'Pagination'];
     private array $ulAttributes = ['class' => 'pagination justify-content-center mt-4'];
-    private string $activePageCssClass = 'active';
-    private string $disabledPageCssClass = 'disabled';
-    private string $firstPageCssClass = 'page-item';
-    private string $lastPageCssClass = 'page-item';
-    private string $nextPageCssClass = 'page-item';
-    private string $pageCssClass = 'page-item';
-    private string $prevPageCssClass = 'page-item';
-    private string $firstPageLabel = '';
-    private string $lastPageLabel = '';
-    private string $nextPageLabel = 'Next Page';
+    private ?string $firstPageLabel = null;
+    private array $firstPageAttributes = [];
+    private ?string $lastPageLabel = null;
+    private array $lastPageAttributes = [
+        'class' => 'page-item',
+    ];
+    private ?string $nextPageLabel = 'Next Page';
+    private array $nextPageAttributes = [
+        'class' => 'page-item',
+    ];
     private string $prevPageLabel = 'Previous';
+    private array $prevPageAttributes = [
+        'class' => 'page-item',
+    ];
     public bool $disableCurrentPageButton = false;
     private string $cssFramework = self::BOOTSTRAP;
     private bool $hideOnSinglePage = false;
@@ -65,8 +80,8 @@ final class LinkPager extends Widget
     private bool $registerLinkTags = false;
     private ?array $requestAttributes = null;
     private ?array $requestQueryParams = null;
-    private CurrentRoute $currentRoute;
     private string $pageParam = 'page';
+    private CurrentRoute $currentRoute;
     private OffsetPaginator $paginator;
     private UrlGeneratorInterface $urlGenerator;
     private WebView $webView;
@@ -83,6 +98,10 @@ final class LinkPager extends Widget
 
     protected function beforeRun(): bool
     {
+        if (!isset($this->paginator)) {
+            throw new InvalidConfigException('The "paginator" property must be set.');
+        }
+
         if ($this->requestAttributes === null) {
             $this->requestAttributes = $this->currentRoute->getArguments();
         }
@@ -111,10 +130,6 @@ final class LinkPager extends Widget
     {
         $this->buildWidget();
 
-        if (!isset($this->paginator)) {
-            throw new InvalidConfigException('The "paginator" property must be set.');
-        }
-
         if ($this->registerLinkTags) {
             $this->registerLinkTagsInternal();
         }
@@ -138,19 +153,6 @@ final class LinkPager extends Widget
     }
 
     /**
-     * @param string the CSS class for the active (currently selected) page button.
-     *
-     * @return $this
-     */
-    public function activePageCssClass(string $activePageCssClass): self
-    {
-        $new = clone $this;
-        $new->activePageCssClass = $activePageCssClass;
-
-        return $new;
-    }
-
-    /**
      * @param array $buttonsContainerAttributes HTML attributes which will be applied to all button containers.
      *
      * @return $this
@@ -164,6 +166,85 @@ final class LinkPager extends Widget
     }
 
     /**
+     * @param array $attributes attributes for the active (currently selected) page button.
+     *
+     * @return self
+     */
+    public function activeButtonAttributes(array $attributes): self
+    {
+        $new = clone $this;
+        $new->activeButtonAttributes = $attributes;
+
+        return $new;
+    }
+
+    /**
+     * @param array $attributes HTML attributes for disabled link container
+     *
+     * @return self
+     */
+    public function disabledButtonAttributes(array $attributes): self
+    {
+        $new = clone $this;
+        $new->disabledButtonAttributes = $attributes;
+
+        return $new;
+    }
+
+    /**
+     * @param array $attributes HTML attributes for the "first" page button.
+     *
+     * @return $this
+     */
+    public function firstPageAttributes(array $attributes): self
+    {
+        $new = clone $this;
+        $new->firstPageAttributes = $attributes;
+
+        return $new;
+    }
+
+    /**
+     * @param string|null the text label for the "first" page button.
+     *
+     * @return $this
+     */
+    public function firstPageLabel(?string $label): self
+    {
+        $new = clone $this;
+        $new->firstPageLabel = $label;
+
+        return $new;
+    }
+
+    /**
+     * @param array $attributes HTML attributes for the "last" page button.
+     *
+     * @return $this
+     */
+    public function lastPageAttributes(array $attributes): self
+    {
+        $new = clone $this;
+        $new->lastPageAttributes = $attributes;
+
+        return $new;
+    }
+
+    /**
+     *
+     * @param string|null the text label for the "last" page button
+     *
+     * @return self
+     */
+    public function lastPageLabel(?string $label): self
+    {
+        $new = clone $this;
+        $new->lastPageLabel = $label;
+
+        return $new;
+    }
+
+    /**
      * @param bool $disableCurrentPageButton whether to render current page button as disabled.
      *
      * @return $this
@@ -172,50 +253,6 @@ final class LinkPager extends Widget
     {
         $new = clone $this;
         $new->disableCurrentPageButton = $disableCurrentPageButton;
-
-        return $new;
-    }
-
-    /**
-     * @param string $disabledPageCssClass the CSS class for the disabled page buttons.
-     *
-     * @return $this
-     */
-    public function disabledPageCssClass(string $disabledPageCssClass): self
-    {
-        $new = clone $this;
-        $new->disabledPageCssClass = $disabledPageCssClass;
-
-        return $new;
-    }
-
-    /**
-     * @param string $firstPageCssClass the CSS class for the "first" page button.
-     *
-     * @return $this
-     */
-    public function firstPageCssClass(string $firstPageCssClass): self
-    {
-        $new = clone $this;
-        $new->firstPageCssClass = $firstPageCssClass;
-
-        return $new;
-    }
-
-    /**
-     * @param string $firstPageLabel the text label for the "first" page button. Note that this will NOT be
-     * HTML-encoded.
-     *
-     * If it's specified as true, page number will be used as label.
-     *
-     * Default is false that means the "first" page button will not be displayed.
-     *
-     * @return $this
-     */
-    public function firstPageLabel(string $firstPageLabel): self
-    {
-        $new = clone $this;
-        $new->firstPageLabel = $firstPageLabel;
 
         return $new;
     }
@@ -247,36 +284,6 @@ final class LinkPager extends Widget
     }
 
     /**
-     * @param string $lastPageCssClass the CSS class for the "last" page button.
-     *
-     * @return $this
-     */
-    public function lastPageCssClass(string $lastPageCssClass): self
-    {
-        $new = clone $this;
-        $new->lastPageCssClass = $lastPageCssClass;
-
-        return $new;
-    }
-
-    /**
-     * @param string $lastPageLabel the text label for the "last" page button. Note that this will NOT be HTML-encoded.
-     *
-     * If it's specified as true, page number will be used as label.
-     *
-     * Default is false that means the "last" page button will not be displayed.
-     *
-     * @return $this
-     */
-    public function lastPageLabel(string $lastPageLabel): self
-    {
-        $new = clone $this;
-        $new->lastPageLabel = $lastPageLabel;
-
-        return $new;
-    }
-
-    /**
      * @param array $linkAttributes HTML attributes for the link in a pager container tag.
      *
      * @return $this
@@ -287,6 +294,32 @@ final class LinkPager extends Widget
     {
         $new = clone $this;
         $new->linkAttributes = $linkAttributes;
+
+        return $new;
+    }
+
+    /**
+     * @param array $attributes HTML attributes for the active (currently selected) link.
+     *
+     * @return self
+     */
+    public function activeLinkAttributes(array $attributes): self
+    {
+        $new = clone $this;
+        $new->activeLinkAttributes = $attributes;
+
+        return $new;
+    }
+
+    /**
+     * @param array $attributes HTML attributes for the disabled link.
+     *
+     * @return self
+     */
+    public function disabledLinkAttributes(array $attributes): self
+    {
+        $new = clone $this;
+        $new->disabledLinkAttributes = $attributes;
 
         return $new;
     }
@@ -305,29 +338,27 @@ final class LinkPager extends Widget
     }
 
     /**
-     * @param string $nextPageCssClass the CSS class for the "next" page button.
+     * @param array $attributes HTML attributes for the "next" page button.
      *
      * @return $this
      */
-    public function nextPageCssClass(string $nextPageCssClass): self
+    public function nextPageAttributes(array $attributes): self
     {
         $new = clone $this;
-        $new->nextPageCssClass = $nextPageCssClass;
+        $new->nextPageAttributes = $attributes;
 
         return $new;
     }
 
     /**
-     * @param string $nextPageLabel the label for the "next" page button. Note that this will NOT be HTML-encoded.
-     *
-     * If this property is false, the "next" page button will not be displayed.
+     * @param string|null $label for the "next" page button
      *
      * @return $this
      */
-    public function nextPageLabel(string $nextPageLabel): self
+    public function nextPageLabel(?string $label): self
     {
         $new = clone $this;
-        $new->nextPageLabel = $nextPageLabel;
+        $new->nextPageLabel = $label;
 
         return $new;
     }
@@ -363,19 +394,6 @@ final class LinkPager extends Widget
     }
 
     /**
-     * @param string $pageCssClass the CSS class for the each page button.
-     *
-     * @return $this
-     */
-    public function pageCssClass(string $pageCssClass): self
-    {
-        $new = clone $this;
-        $new->pageCssClass = $pageCssClass;
-
-        return $new;
-    }
-
-    /**
      * @param OffsetPaginator $paginator set paginator {@see OffsetPaginator} {@see KeysetPaginator}.
      *
      * @return $this
@@ -389,30 +407,27 @@ final class LinkPager extends Widget
     }
 
     /**
-     * @param string $prevPageCssClass the CSS class for the "previous" page button.
+     * @param array $attributes HTML attributes for the "previous" page button.
      *
      * @return $this
      */
-    public function prevPageCssClass(string $prevPageCssClass): self
+    public function prevPageAttributes(array $attributes): self
     {
         $new = clone $this;
-        $new->prevPageCssClass = $prevPageCssClass;
+        $new->prevPageAttributes = $attributes;
 
         return $new;
     }
 
     /**
-     * @param string $prevPageLabel the text label for the "previous" page button. Note that this will NOT
-     * be HTML-encoded.
-     *
-     * If this property is false, the "previous" page button will not be displayed.
+     * @param string|null $label the text label for the "previous" page button.
      *
      * @return $this
      */
-    public function prevPageLabel(string $prevPageLabel): self
+    public function prevPageLabel(?string $label): self
     {
         $new = clone $this;
-        $new->prevPageLabel = $prevPageLabel;
+        $new->prevPageLabel = $label;
 
         return $new;
     }
@@ -470,6 +485,26 @@ final class LinkPager extends Widget
     }
 
     /**
+     * Merge default/main attributes for current attributes to active/disabled/etc status
+     *
+     * @param array $mainAttributes
+     * @param array $additionalAttributes
+     *
+     * @return array
+     */
+    private static function mergeAttributes(array $mainAttributes, array $additionalAttributes): array
+    {
+        $class = ArrayHelper::remove($additionalAttributes, 'class');
+        $attributes = array_merge($mainAttributes, $additionalAttributes);
+
+        if ($class) {
+            Html::addCssClass($attributes, $class);
+        }
+
+        return $attributes;
+    }
+
+    /**
      * Renders the page buttons.
      *
      * @throws JsonException
@@ -485,11 +520,11 @@ final class LinkPager extends Widget
             return '';
         }
 
-        $renderFirstPageButtonLink = $this->renderFirstPageButtonLink();
+        $renderFirstPageButtonLink = $this->renderFirstPageButtonLink($currentPage);
         $renderPreviousPageButtonLink = $this->renderPreviousPageButtonLink($currentPage);
         $renderPageButtonLinks = $this->renderPageButtonLinks($currentPage);
         $renderNextPageButtonLink = $this->renderNextPageButtonLink($currentPage, $pageCount);
-        $renderLastPageButtonLink = $this->renderLastPageButtonLink($pageCount);
+        $renderLastPageButtonLink = $this->renderLastPageButtonLink($currentPage, $pageCount);
 
         /** @psalm-var non-empty-string */
         $tag = ArrayHelper::remove($this->ulAttributes, 'tag', 'ul');
@@ -507,7 +542,7 @@ final class LinkPager extends Widget
                     "\n",
                     $this->ulAttributes
                 )->encode(false) . "\n" .
-            Html::closeTag('nav') . "\n";
+            Html::closeTag('nav');
 
         if ($this->cssFramework === self::BULMA) {
             $html =
@@ -549,21 +584,19 @@ final class LinkPager extends Widget
         $linkAttributes['data-page'] = $page;
 
         if ($active && !$disabled) {
-            Html::addCssClass($buttonsAttributes, $this->activePageCssClass);
+            $linkAttributes = self::mergeAttributes($linkAttributes, $this->activeLinkAttributes);
+            $buttonsAttributes = self::mergeAttributes($buttonsAttributes, $this->activeButtonAttributes);
+        } elseif ($disabled) {
+            $linkAttributes = self::mergeAttributes($linkAttributes, $this->disabledLinkAttributes);
+            $buttonsAttributes = self::mergeAttributes($buttonsAttributes, $this->disabledButtonAttributes);
+
+            if (!$active) {
+                $linkAttributes['aria-disabled'] = 'true';
+                $linkAttributes['tabindex'] = '-1';
+            }
         }
 
-        if ($disabled && !$active) {
-            $linkAttributes['aria-disabled'] = 'true';
-            $linkAttributes['tabindex'] = '-1';
-        }
-
-        if ($disabled && $this->cssFramework === self::BOOTSTRAP) {
-            Html::addCssClass($buttonsAttributes, $this->disabledPageCssClass);
-        }
-
-        if ($disabled && $this->cssFramework === self::BULMA) {
-            $buttonsAttributes['disabled'] = true;
-        }
+        $encode = is_numeric($label) ? false : ArrayHelper::remove($buttonsAttributes, 'encode', true);
 
         return Html::tag(
             $linkWrapTag,
@@ -571,7 +604,7 @@ final class LinkPager extends Widget
                 $label,
                 $this->createUrl($page),
                 $linkAttributes
-            )->render()
+            )->encode($encode)->render()
         )
         ->attributes($buttonsAttributes)
         ->encode(false)
@@ -655,40 +688,41 @@ final class LinkPager extends Widget
         $this->navAttributes['class'] = 'pagination is-centered mt-4';
         $this->ulAttributes['class'] = 'pagination-list justify-content-center mt-4';
         $this->linkAttributes = [];
-        $this->pageCssClass = 'pagination-link';
-        $this->firstPageCssClass = 'pagination-previous';
-        $this->lastPageCssClass = 'pagination-next';
-        $this->prevPageCssClass = 'pagination-previous has-background-link has-text-white';
-        $this->nextPageCssClass = 'pagination-next has-background-link has-text-white';
-        $this->activePageCssClass = 'is-current';
-        $this->disabledPageCssClass = 'disabled';
+        $this->buttonsContainerAttributes = ['class' => 'pagination-link'];
+        $this->firstPageAttributes = ['class' => 'pagination-previous'];
+        $this->lastPageAttributes = ['class' => 'pagination-next'];
+        $this->prevPageAttributes = ['class' => 'pagination-previous has-background-link has-text-white'];
+        $this->nextPageAttributes = ['class' => 'pagination-next has-background-link has-text-white'];
+        $this->activeButtonAttributes = ['class' => 'is-current'];
+        $this->disabledButtonAttributes = ['disabled' => true];
     }
 
-    private function renderFirstPageButtonLink(): string
+    private function renderFirstPageButtonLink(int $currentPage): string
     {
-        $html = '';
-
-        if ($this->firstPageLabel !== '') {
-            $html = $this->renderPageButton($this->firstPageLabel, 1, ['class' => $this->firstPageCssClass]);
+        if ($this->firstPageLabel === null) {
+            return '';
         }
 
-        return $html !== '' ? $html . "\n" : '';
+        return $this->renderPageButton(
+            $this->firstPageLabel,
+            1,
+            $this->firstPageAttributes,
+            $currentPage === 1
+        );
     }
 
     private function renderPreviousPageButtonLink(int $currentPage): string
     {
-        $html = '';
-
-        if ($this->prevPageLabel !== '') {
-            $html = $this->renderPageButton(
-                $this->prevPageLabel,
-                max($currentPage - 1, 1),
-                ['class' => $this->prevPageCssClass],
-                $currentPage === 1,
-            );
+        if ($this->prevPageLabel === null) {
+            return '';
         }
 
-        return $html;
+        return $this->renderPageButton(
+            $this->prevPageLabel,
+            max($currentPage - 1, 1),
+            $this->prevPageAttributes,
+            $currentPage === 1
+        );
     }
 
     /**
@@ -706,8 +740,6 @@ final class LinkPager extends Widget
          */
         [$beginPage, $endPage] = $this->getPageRange();
 
-        Html::addCssClass($this->buttonsContainerAttributes, $this->pageCssClass);
-
         for ($i = $beginPage; $i <= $endPage; ++$i) {
             $buttons[] = $this->renderPageButton(
                 (string) $i,
@@ -723,32 +755,29 @@ final class LinkPager extends Widget
 
     private function renderNextPageButtonLink(int $currentPage, int $pageCount): string
     {
-        $html = '';
-
-        if ($this->nextPageLabel !== '') {
-            $html = $this->renderPageButton(
-                $this->nextPageLabel,
-                min($pageCount, $currentPage + 1),
-                ['class' => $this->nextPageCssClass],
-                $currentPage === $pageCount,
-            );
-
-            if ($this->lastPageLabel !== '') {
-                $html .= "\n";
-            }
+        if ($this->nextPageLabel === null) {
+            return '';
         }
 
-        return $html;
+        return $this->renderPageButton(
+            $this->nextPageLabel,
+            min($pageCount, $currentPage + 1),
+            $this->nextPageAttributes,
+            $currentPage === $pageCount,
+        );
     }
 
-    private function renderLastPageButtonLink(int $pageCount): string
+    private function renderLastPageButtonLink(int $currentPage, int $pageCount): string
     {
-        $html = '';
-
-        if ($this->lastPageLabel !== '') {
-            $html = $this->renderPageButton($this->lastPageLabel, $pageCount, ['class' => $this->lastPageCssClass]);
+        if ($this->lastPageLabel === null) {
+            return '';
         }
 
-        return $html;
+        return $this->renderPageButton(
+            $this->lastPageLabel,
+            $pageCount,
+            $this->lastPageAttributes,
+            $currentPage === $pageCount
+        );
     }
 }

--- a/src/Widget/LinkSorter.php
+++ b/src/Widget/LinkSorter.php
@@ -198,19 +198,17 @@ final class LinkSorter extends Widget
      */
     private function createUrl(string $attribute): string
     {
-        $action = '';
         $params = [];
         $params['sort'] = $this->createSorterParam($attribute);
         $page = ['page' => $this->currentPage];
         $params = array_merge($page, $this->requestAttributes, $this->requestQueryParams, $params);
 
-        $currentRoute = $this->currentRoute->getRoute();
 
-        if ($currentRoute !== null) {
-            $action = $currentRoute->getName();
+        if ($name = $this->currentRoute->getName()) {
+            return $this->urlGenerator->generate($name, $params);
         }
 
-        return $this->urlGenerator->generate($action, $params);
+        return '?' . http_build_query($params);
     }
 
     /**

--- a/src/Widget/LinkSorter.php
+++ b/src/Widget/LinkSorter.php
@@ -35,8 +35,8 @@ final class LinkSorter extends Widget
     private int $currentPage = 1;
     private string $cssFramework = self::BOOTSTRAP;
     private array $options = [];
-    private array $requestAttributes = [];
-    private array $requestQueryParams = [];
+    private ?array $requestArguments = null;
+    private ?array $requestQueryParams = null;
     private CurrentRoute $currentRoute;
     private Inflector $inflector;
     private Sort $sort;
@@ -50,6 +50,23 @@ final class LinkSorter extends Widget
         $this->currentRoute = $currentRoute;
         $this->inflector = $inflector;
         $this->urlGenerator = $urlGenerator;
+    }
+
+    protected function beforeRun(): bool
+    {
+        if ($this->requestArguments === null) {
+            $this->requestArguments = $this->currentRoute->getArguments();
+        }
+
+        if ($this->requestQueryParams === null) {
+            $this->requestQueryParams = [];
+
+            if ($uri = $this->currentRoute->getUri()) {
+                parse_str($uri->getQuery(), $this->requestQueryParams);
+            }
+        }
+
+        return parent::beforeRun();
     }
 
     /**
@@ -110,15 +127,15 @@ final class LinkSorter extends Widget
         return $new;
     }
 
-    public function requestAttributes(array $requestAttributes): self
+    public function requestArguments(?array $requestArguments): self
     {
         $new = clone $this;
-        $new->requestAttributes = $requestAttributes;
+        $new->requestArguments = $requestArguments;
 
         return $new;
     }
 
-    public function requestQueryParams(array $requestQueryParams): self
+    public function requestQueryParams(?array $requestQueryParams): self
     {
         $new = clone $this;
         $new->requestQueryParams = $requestQueryParams;
@@ -201,14 +218,13 @@ final class LinkSorter extends Widget
         $params = [];
         $params['sort'] = $this->createSorterParam($attribute);
         $page = ['page' => $this->currentPage];
-        $params = array_merge($page, $this->requestAttributes, $this->requestQueryParams, $params);
-
+        $queryParams = array_merge($page, $this->requestQueryParams, $params);
 
         if ($name = $this->currentRoute->getName()) {
-            return $this->urlGenerator->generate($name, $params);
+            return $this->urlGenerator->generate($name, $this->requestArguments, $queryParams);
         }
 
-        return '?' . http_build_query($params);
+        return '?' . http_build_query($queryParams);
     }
 
     /**

--- a/tests/Column/DataColumnTest.php
+++ b/tests/Column/DataColumnTest.php
@@ -46,7 +46,7 @@ final class DataColumnTest extends TestCase
         </nav>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($gridView->render()));
+        $this->assertEqualsHTML($html, $gridView->render());
     }
 
     public function testAttributeStringFormat(): void
@@ -80,7 +80,7 @@ final class DataColumnTest extends TestCase
         </nav>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($gridView->render()));
+        $this->assertEqualsHTML($html, $gridView->render());
     }
 
     public function testContent(): void
@@ -123,7 +123,7 @@ final class DataColumnTest extends TestCase
         </nav>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($gridView->render()));
+        $this->assertEqualsHTML($html, $gridView->render());
     }
 
     public function testContentIsEmpty(): void
@@ -166,7 +166,7 @@ final class DataColumnTest extends TestCase
         </nav>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($gridView->render()));
+        $this->assertEqualsHTML($html, $gridView->render());
     }
 
     public function testContentOptions(): void
@@ -205,7 +205,7 @@ final class DataColumnTest extends TestCase
         </nav>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($gridView->render()));
+        $this->assertEqualsHTML($html, $gridView->render());
     }
 
     public function testFilter(): void
@@ -248,7 +248,7 @@ final class DataColumnTest extends TestCase
         </nav>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($gridView->render()));
+        $this->assertEqualsHTML($html, $gridView->render());
     }
 
     public function testFilterInputOptions(): void
@@ -291,7 +291,7 @@ final class DataColumnTest extends TestCase
         </nav>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($gridView->render()));
+        $this->assertEqualsHTML($html, $gridView->render());
 
         $columns = [
             [
@@ -329,7 +329,7 @@ final class DataColumnTest extends TestCase
         </nav>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($gridView->render()));
+        $this->assertEqualsHTML($html, $gridView->render());
     }
 
     public function testFilterOptions(): void
@@ -372,7 +372,7 @@ final class DataColumnTest extends TestCase
         </nav>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($gridView->render()));
+        $this->assertEqualsHTML($html, $gridView->render());
     }
 
     public function testFilterValueDefault(): void
@@ -415,7 +415,7 @@ final class DataColumnTest extends TestCase
         </nav>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($gridView->render()));
+        $this->assertEqualsHTML($html, $gridView->render());
     }
 
     public function testFooter(): void
@@ -458,7 +458,7 @@ final class DataColumnTest extends TestCase
         </nav>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($gridView->render()));
+        $this->assertEqualsHTML($html, $gridView->render());
     }
 
     public function testFooterOptions(): void
@@ -501,7 +501,7 @@ final class DataColumnTest extends TestCase
         </nav>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($gridView->render()));
+        $this->assertEqualsHTML($html, $gridView->render());
     }
 
     public function testHeader(): void
@@ -538,7 +538,7 @@ final class DataColumnTest extends TestCase
         $html = <<<'HTML'
         <tr><th class="has-text-danger">id</th><th>name</th><th>total</th></tr>
         HTML;
-        $this->assertStringContainsString($this->removeLE($html), $this->removeLE($gridView->render()));
+        $this->assertStringContainsString($html, $gridView->render());
     }
 
     public function testLabel(): void
@@ -557,7 +557,7 @@ final class DataColumnTest extends TestCase
         $html = <<<'HTML'
         <tr><th>id</th><th>name</th><th>total</th></tr>
         HTML;
-        $this->assertStringContainsString($this->removeLE($html), $this->removeLE($gridView->render()));
+        $this->assertStringContainsString($html, $gridView->render());
     }
 
     public function testLabelEmpty(): void
@@ -570,7 +570,7 @@ final class DataColumnTest extends TestCase
         $html = <<<'HTML'
         <tr><th>Id</th><th>Name</th><th>Total</th></tr>
         HTML;
-        $this->assertStringContainsString($this->removeLE($html), $this->removeLE($gridView->render()));
+        $this->assertStringContainsString($html, $gridView->render());
     }
 
     public function testNotEncodeLabel(): void
@@ -609,7 +609,7 @@ final class DataColumnTest extends TestCase
         </nav>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($gridView->render()));
+        $this->assertEqualsHTML($html, $gridView->render());
 
         $columns = [
             [
@@ -647,7 +647,7 @@ final class DataColumnTest extends TestCase
         </nav>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($gridView->render()));
+        $this->assertEqualsHTML($html, $gridView->render());
     }
 
     public function testSorting(): void
@@ -686,7 +686,7 @@ final class DataColumnTest extends TestCase
         </nav>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($gridView->render()));
+        $this->assertEqualsHTML($html, $gridView->render());
 
 
         $gridView = $this->createGridView(['id', 'name']);
@@ -715,7 +715,7 @@ final class DataColumnTest extends TestCase
         </nav>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($gridView->render()));
+        $this->assertEqualsHTML($html, $gridView->render());
     }
 
     public function testSortingDisable(): void
@@ -760,7 +760,7 @@ final class DataColumnTest extends TestCase
         </nav>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($gridView->render()));
+        $this->assertEqualsHTML($html, $gridView->render());
     }
 
     public function testSortLinkOption(): void
@@ -805,7 +805,7 @@ final class DataColumnTest extends TestCase
         </nav>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($gridView->render()));
+        $this->assertEqualsHTML($html, $gridView->render());
     }
 
     public function testInvisible(): void
@@ -881,7 +881,7 @@ final class DataColumnTest extends TestCase
         </nav>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($gridView->render()));
+        $this->assertEqualsHTML($html, $gridView->render());
 
         $columns = [
             'id',
@@ -919,6 +919,6 @@ final class DataColumnTest extends TestCase
         </nav>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($gridView->render()));
+        $this->assertEqualsHTML($html, $gridView->render());
     }
 }

--- a/tests/Column/DataColumnTest.php
+++ b/tests/Column/DataColumnTest.php
@@ -46,7 +46,7 @@ final class DataColumnTest extends TestCase
         </nav>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($html, $gridView->render());
+        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($gridView->render()));
     }
 
     public function testAttributeStringFormat(): void
@@ -80,7 +80,7 @@ final class DataColumnTest extends TestCase
         </nav>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($html, $gridView->render());
+        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($gridView->render()));
     }
 
     public function testContent(): void
@@ -123,7 +123,7 @@ final class DataColumnTest extends TestCase
         </nav>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($html, $gridView->render());
+        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($gridView->render()));
     }
 
     public function testContentIsEmpty(): void
@@ -166,7 +166,7 @@ final class DataColumnTest extends TestCase
         </nav>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($html, $gridView->render());
+        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($gridView->render()));
     }
 
     public function testContentOptions(): void
@@ -205,7 +205,7 @@ final class DataColumnTest extends TestCase
         </nav>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($html, $gridView->render());
+        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($gridView->render()));
     }
 
     public function testFilter(): void
@@ -248,7 +248,7 @@ final class DataColumnTest extends TestCase
         </nav>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($html, $gridView->render());
+        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($gridView->render()));
     }
 
     public function testFilterInputOptions(): void
@@ -291,7 +291,7 @@ final class DataColumnTest extends TestCase
         </nav>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($html, $gridView->render());
+        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($gridView->render()));
 
         $columns = [
             [
@@ -329,7 +329,7 @@ final class DataColumnTest extends TestCase
         </nav>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($html, $gridView->render());
+        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($gridView->render()));
     }
 
     public function testFilterOptions(): void
@@ -372,7 +372,7 @@ final class DataColumnTest extends TestCase
         </nav>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($html, $gridView->render());
+        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($gridView->render()));
     }
 
     public function testFilterValueDefault(): void
@@ -415,7 +415,7 @@ final class DataColumnTest extends TestCase
         </nav>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($html, $gridView->render());
+        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($gridView->render()));
     }
 
     public function testFooter(): void
@@ -458,7 +458,7 @@ final class DataColumnTest extends TestCase
         </nav>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($html, $gridView->render());
+        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($gridView->render()));
     }
 
     public function testFooterOptions(): void
@@ -501,7 +501,7 @@ final class DataColumnTest extends TestCase
         </nav>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($html, $gridView->render());
+        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($gridView->render()));
     }
 
     public function testHeader(): void
@@ -538,7 +538,7 @@ final class DataColumnTest extends TestCase
         $html = <<<'HTML'
         <tr><th class="has-text-danger">id</th><th>name</th><th>total</th></tr>
         HTML;
-        $this->assertStringContainsString($html, $gridView->render());
+        $this->assertStringContainsString($this->removeLE($html), $this->removeLE($gridView->render()));
     }
 
     public function testLabel(): void
@@ -557,7 +557,7 @@ final class DataColumnTest extends TestCase
         $html = <<<'HTML'
         <tr><th>id</th><th>name</th><th>total</th></tr>
         HTML;
-        $this->assertStringContainsString($html, $gridView->render());
+        $this->assertStringContainsString($this->removeLE($html), $this->removeLE($gridView->render()));
     }
 
     public function testLabelEmpty(): void
@@ -570,7 +570,7 @@ final class DataColumnTest extends TestCase
         $html = <<<'HTML'
         <tr><th>Id</th><th>Name</th><th>Total</th></tr>
         HTML;
-        $this->assertStringContainsString($html, $gridView->render());
+        $this->assertStringContainsString($this->removeLE($html), $this->removeLE($gridView->render()));
     }
 
     public function testNotEncodeLabel(): void
@@ -609,7 +609,7 @@ final class DataColumnTest extends TestCase
         </nav>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($html, $gridView->render());
+        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($gridView->render()));
 
         $columns = [
             [
@@ -647,7 +647,7 @@ final class DataColumnTest extends TestCase
         </nav>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($html, $gridView->render());
+        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($gridView->render()));
     }
 
     public function testSorting(): void
@@ -686,7 +686,7 @@ final class DataColumnTest extends TestCase
         </nav>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($html, $gridView->render());
+        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($gridView->render()));
 
 
         $gridView = $this->createGridView(['id', 'name']);
@@ -715,7 +715,7 @@ final class DataColumnTest extends TestCase
         </nav>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($html, $gridView->render());
+        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($gridView->render()));
     }
 
     public function testSortingDisable(): void
@@ -760,7 +760,7 @@ final class DataColumnTest extends TestCase
         </nav>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($html, $gridView->render());
+        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($gridView->render()));
     }
 
     public function testSortLinkOption(): void
@@ -805,7 +805,7 @@ final class DataColumnTest extends TestCase
         </nav>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($html, $gridView->render());
+        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($gridView->render()));
     }
 
     public function testInvisible(): void
@@ -881,7 +881,7 @@ final class DataColumnTest extends TestCase
         </nav>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($html, $gridView->render());
+        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($gridView->render()));
 
         $columns = [
             'id',
@@ -919,6 +919,6 @@ final class DataColumnTest extends TestCase
         </nav>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($html, $gridView->render());
+        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($gridView->render()));
     }
 }

--- a/tests/Column/DataColumnTest.php
+++ b/tests/Column/DataColumnTest.php
@@ -654,8 +654,9 @@ final class DataColumnTest extends TestCase
     {
         GridView::counter(0);
 
-        $this->currentRoute->setRoute(
+        $this->currentRoute->setRouteWithArguments(
             Route::methods(['GET', 'POST'], '/admin/index')->action([TestDelete::class, 'run'])->name('admin'),
+            []
         );
 
         $gridView = $this->createGridView(['id', 'name']);
@@ -721,8 +722,9 @@ final class DataColumnTest extends TestCase
     {
         GridView::counter(0);
 
-        $this->currentRoute->setRoute(
+        $this->currentRoute->setRouteWithArguments(
             Route::methods(['GET', 'POST'], '/admin/index')->action([TestDelete::class, 'run'])->name('admin'),
+            []
         );
 
         $gridView = $this->createGridView(
@@ -765,8 +767,9 @@ final class DataColumnTest extends TestCase
     {
         GridView::counter(0);
 
-        $this->currentRoute->setRoute(
+        $this->currentRoute->setRouteWithArguments(
             Route::methods(['GET', 'POST'], '/admin/index')->action([TestDelete::class, 'run'])->name('admin'),
+            []
         );
 
         $gridView = $this->createGridView(

--- a/tests/Column/RadioButtonColumnTest.php
+++ b/tests/Column/RadioButtonColumnTest.php
@@ -50,7 +50,7 @@ final class RadioButtonColumnTest extends TestCase
         </nav>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($html, $gridView->render());
+        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($gridView->render()));
     }
 
     public function testName(): void
@@ -91,7 +91,7 @@ final class RadioButtonColumnTest extends TestCase
         </nav>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($html, $gridView->render());
+        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($gridView->render()));
     }
 
     public function testRadioOptions(): void
@@ -132,7 +132,7 @@ final class RadioButtonColumnTest extends TestCase
         </nav>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($html, $gridView->render());
+        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($gridView->render()));
 
         $columns = [
             'id',
@@ -171,7 +171,7 @@ final class RadioButtonColumnTest extends TestCase
         </nav>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($html, $gridView->render());
+        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($gridView->render()));
     }
 
     public function testNameIsEmpty(): void

--- a/tests/Column/RadioButtonColumnTest.php
+++ b/tests/Column/RadioButtonColumnTest.php
@@ -50,7 +50,7 @@ final class RadioButtonColumnTest extends TestCase
         </nav>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($gridView->render()));
+        $this->assertEqualsHTML($html, $gridView->render());
     }
 
     public function testName(): void
@@ -91,7 +91,7 @@ final class RadioButtonColumnTest extends TestCase
         </nav>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($gridView->render()));
+        $this->assertEqualsHTML($html, $gridView->render());
     }
 
     public function testRadioOptions(): void
@@ -132,7 +132,7 @@ final class RadioButtonColumnTest extends TestCase
         </nav>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($gridView->render()));
+        $this->assertEqualsHTML($html, $gridView->render());
 
         $columns = [
             'id',
@@ -171,7 +171,7 @@ final class RadioButtonColumnTest extends TestCase
         </nav>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($gridView->render()));
+        $this->assertEqualsHTML($html, $gridView->render());
     }
 
     public function testNameIsEmpty(): void

--- a/tests/Column/SerialColumnTest.php
+++ b/tests/Column/SerialColumnTest.php
@@ -48,6 +48,6 @@ final class SerialColumnTest extends TestCase
         </nav>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($gridView->render()));
+        $this->assertEqualsHTML($html, $gridView->render());
     }
 }

--- a/tests/Column/SerialColumnTest.php
+++ b/tests/Column/SerialColumnTest.php
@@ -48,6 +48,6 @@ final class SerialColumnTest extends TestCase
         </nav>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($html, $gridView->render());
+        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($gridView->render()));
     }
 }

--- a/tests/GridViewTest.php
+++ b/tests/GridViewTest.php
@@ -53,7 +53,7 @@ final class GridViewTest extends TestCase
         </table>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($html, $gridView->render());
+        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($gridView->render()));
     }
 
     public function testAutoIdPrefix(): void
@@ -77,7 +77,7 @@ final class GridViewTest extends TestCase
         </table>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($html, $gridView->render());
+        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($gridView->render()));
     }
 
     public function testCaption(): void
@@ -375,7 +375,7 @@ final class GridViewTest extends TestCase
         </nav>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($html, $gridView->render());
+        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($gridView->render()));
 
         $gridView = $gridView
             ->filterModelName('testMe')
@@ -410,7 +410,7 @@ final class GridViewTest extends TestCase
         </nav>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($html, $gridView->render());
+        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($gridView->render()));
     }
 
     public function testFilterRowOptions(): void
@@ -458,7 +458,7 @@ final class GridViewTest extends TestCase
         </nav>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($html, $gridView->render());
+        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($gridView->render()));
     }
 
     public function testFooterRowOptions(): void
@@ -498,7 +498,7 @@ final class GridViewTest extends TestCase
         </nav>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($html, $gridView->render());
+        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($gridView->render()));
     }
 
     public function testInvalidCssFrameworkException(): void
@@ -540,7 +540,7 @@ final class GridViewTest extends TestCase
         </table>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($html, $gridView->render());
+        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($gridView->render()));
     }
 
     public function testHeaderRowOptions(): void
@@ -575,7 +575,7 @@ final class GridViewTest extends TestCase
         </table>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($html, $gridView->render());
+        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($gridView->render()));
     }
 
     public function testId(): void
@@ -599,7 +599,7 @@ final class GridViewTest extends TestCase
         </table>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($html, $gridView->render());
+        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($gridView->render()));
     }
 
     public function testLayout(): void
@@ -637,7 +637,7 @@ final class GridViewTest extends TestCase
         </nav>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($html, $gridView->render());
+        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($gridView->render()));
     }
 
     public function testPaginatorEmpty(): void
@@ -681,7 +681,7 @@ final class GridViewTest extends TestCase
         </table>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($html, $gridView->render());
+        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($gridView->render()));
     }
 
     public function testRenderSummary(): void
@@ -710,7 +710,7 @@ final class GridViewTest extends TestCase
         </table>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($html, $gridView->render());
+        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($gridView->render()));
     }
 
     public function testRequestAttributes(): void
@@ -753,7 +753,7 @@ final class GridViewTest extends TestCase
         </nav>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($html, $gridView->render());
+        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($gridView->render()));
     }
 
     public function testRequestQueryParams(): void
@@ -796,7 +796,7 @@ final class GridViewTest extends TestCase
         </nav>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($html, $gridView->render());
+        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($gridView->render()));
     }
 
     public function testRowOptions(): void
@@ -830,7 +830,7 @@ final class GridViewTest extends TestCase
         </nav>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($html, $gridView->render());
+        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($gridView->render()));
     }
 
     public function testShowFooter(): void
@@ -867,7 +867,7 @@ final class GridViewTest extends TestCase
         </nav>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($html, $gridView->render());
+        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($gridView->render()));
     }
 
     public function testSummaryOptions(): void
@@ -897,7 +897,7 @@ final class GridViewTest extends TestCase
         </table>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($html, $gridView->render());
+        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($gridView->render()));
     }
 
     public function testShowOnEmpty(): void
@@ -912,7 +912,7 @@ final class GridViewTest extends TestCase
         $html = <<<'HTML'
         <div id="w1-gridview" class="grid-view"><div class="empty">No results found.</div></div>
         HTML;
-        $this->assertEqualsWithoutLE($html, $gridView->render());
+        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($gridView->render()));
     }
 
     public function testTableOptions(): void
@@ -948,6 +948,6 @@ final class GridViewTest extends TestCase
         </nav>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($html, $gridView->render());
+        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($gridView->render()));
     }
 }

--- a/tests/GridViewTest.php
+++ b/tests/GridViewTest.php
@@ -717,8 +717,9 @@ final class GridViewTest extends TestCase
     {
         GridView::counter(0);
 
-        $this->currentRoute->setRoute(
+        $this->currentRoute->setRouteWithArguments(
             Route::methods(['GET', 'POST'], '/admin/index')->action([TestDelete::class, 'run'])->name('admin'),
+            []
         );
 
         $gridView = GridView::widget()
@@ -744,10 +745,10 @@ final class GridViewTest extends TestCase
         </table>
         <nav aria-label="Pagination">
         <ul class="pagination justify-content-center mt-4">
-        <li class="page-item disabled"><a class="page-link" href="/admin/index?page=1&amp;filter=1" data-page="1" aria-disabled="true" tabindex="-1">Previous</a></li>
-        <li class="page-item active"><a class="page-link" href="/admin/index?page=1&amp;filter=1" data-page="1">1</a></li>
-        <li class="page-item"><a class="page-link" href="/admin/index?page=2&amp;filter=1" data-page="2">2</a></li>
-        <li class="page-item"><a class="page-link" href="/admin/index?page=2&amp;filter=1" data-page="2">Next Page</a></li>
+        <li class="page-item disabled"><a class="page-link" href="/admin/index?filter=1&amp;page=1" data-page="1" aria-disabled="true" tabindex="-1">Previous</a></li>
+        <li class="page-item active"><a class="page-link" href="/admin/index?filter=1&amp;page=1" data-page="1">1</a></li>
+        <li class="page-item"><a class="page-link" href="/admin/index?filter=1&amp;page=2" data-page="2">2</a></li>
+        <li class="page-item"><a class="page-link" href="/admin/index?filter=1&amp;page=2" data-page="2">Next Page</a></li>
         </ul>
         </nav>
         </div>
@@ -759,8 +760,9 @@ final class GridViewTest extends TestCase
     {
         GridView::counter(0);
 
-        $this->currentRoute->setRoute(
+        $this->currentRoute->setRouteWithArguments(
             Route::methods(['GET', 'POST'], '/admin/index')->action([TestDelete::class, 'run'])->name('admin'),
+            []
         );
 
         $gridView = GridView::widget()
@@ -786,10 +788,10 @@ final class GridViewTest extends TestCase
         </table>
         <nav aria-label="Pagination">
         <ul class="pagination justify-content-center mt-4">
-        <li class="page-item disabled"><a class="page-link" href="/admin/index?page=1&amp;filter=1" data-page="1" aria-disabled="true" tabindex="-1">Previous</a></li>
-        <li class="page-item active"><a class="page-link" href="/admin/index?page=1&amp;filter=1" data-page="1">1</a></li>
-        <li class="page-item"><a class="page-link" href="/admin/index?page=2&amp;filter=1" data-page="2">2</a></li>
-        <li class="page-item"><a class="page-link" href="/admin/index?page=2&amp;filter=1" data-page="2">Next Page</a></li>
+        <li class="page-item disabled"><a class="page-link" href="/admin/index?filter=1&amp;page=1" data-page="1" aria-disabled="true" tabindex="-1">Previous</a></li>
+        <li class="page-item active"><a class="page-link" href="/admin/index?filter=1&amp;page=1" data-page="1">1</a></li>
+        <li class="page-item"><a class="page-link" href="/admin/index?filter=1&amp;page=2" data-page="2">2</a></li>
+        <li class="page-item"><a class="page-link" href="/admin/index?filter=1&amp;page=2" data-page="2">Next Page</a></li>
         </ul>
         </nav>
         </div>

--- a/tests/GridViewTest.php
+++ b/tests/GridViewTest.php
@@ -53,7 +53,7 @@ final class GridViewTest extends TestCase
         </table>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($gridView->render()));
+        $this->assertEqualsWithoutLE($html, $gridView->render());
     }
 
     public function testAutoIdPrefix(): void
@@ -77,7 +77,7 @@ final class GridViewTest extends TestCase
         </table>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($gridView->render()));
+        $this->assertEqualsWithoutLE($html, $gridView->render());
     }
 
     public function testCaption(): void
@@ -375,7 +375,7 @@ final class GridViewTest extends TestCase
         </nav>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($gridView->render()));
+        $this->assertEqualsHTML($html, $gridView->render());
 
         $gridView = $gridView
             ->filterModelName('testMe')
@@ -410,7 +410,7 @@ final class GridViewTest extends TestCase
         </nav>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($gridView->render()));
+        $this->assertEqualsHTML($html, $gridView->render());
     }
 
     public function testFilterRowOptions(): void
@@ -458,7 +458,7 @@ final class GridViewTest extends TestCase
         </nav>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($gridView->render()));
+        $this->assertEqualsHTML($html, $gridView->render());
     }
 
     public function testFooterRowOptions(): void
@@ -498,7 +498,7 @@ final class GridViewTest extends TestCase
         </nav>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($gridView->render()));
+        $this->assertEqualsHTML($html, $gridView->render());
     }
 
     public function testInvalidCssFrameworkException(): void
@@ -540,7 +540,7 @@ final class GridViewTest extends TestCase
         </table>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($gridView->render()));
+        $this->assertEqualsWithoutLE($html, $gridView->render());
     }
 
     public function testHeaderRowOptions(): void
@@ -575,7 +575,7 @@ final class GridViewTest extends TestCase
         </table>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($gridView->render()));
+        $this->assertEqualsWithoutLE($html, $gridView->render());
     }
 
     public function testId(): void
@@ -599,7 +599,7 @@ final class GridViewTest extends TestCase
         </table>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($gridView->render()));
+        $this->assertEqualsWithoutLE($html, $gridView->render());
     }
 
     public function testLayout(): void
@@ -637,7 +637,7 @@ final class GridViewTest extends TestCase
         </nav>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($gridView->render()));
+        $this->assertEqualsHTML($html, $gridView->render());
     }
 
     public function testPaginatorEmpty(): void
@@ -681,7 +681,7 @@ final class GridViewTest extends TestCase
         </table>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($gridView->render()));
+        $this->assertEqualsWithoutLE($html, $gridView->render());
     }
 
     public function testRenderSummary(): void
@@ -710,10 +710,10 @@ final class GridViewTest extends TestCase
         </table>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($gridView->render()));
+        $this->assertEqualsWithoutLE($html, $gridView->render());
     }
 
-    public function testRequestAttributes(): void
+    public function testRequestArguments(): void
     {
         GridView::counter(0);
 
@@ -727,7 +727,7 @@ final class GridViewTest extends TestCase
             ->currentPage(1)
             ->paginator($this->createOffsetPaginator())
             ->pageSize(5)
-            ->requestAttributes(['filter' => 1]);
+            ->requestArguments(['filter' => 1]);
 
         $html = <<<'HTML'
         <div id="w1-gridview" class="grid-view"><div>Showing <b>1-5</b> of <b>6</b> items</div>
@@ -753,7 +753,7 @@ final class GridViewTest extends TestCase
         </nav>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($gridView->render()));
+        $this->assertEqualsHTML($html, $gridView->render());
     }
 
     public function testRequestQueryParams(): void
@@ -796,7 +796,7 @@ final class GridViewTest extends TestCase
         </nav>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($gridView->render()));
+        $this->assertEqualsHTML($html, $gridView->render());
     }
 
     public function testRowOptions(): void
@@ -830,7 +830,7 @@ final class GridViewTest extends TestCase
         </nav>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($gridView->render()));
+        $this->assertEqualsHTML($html, $gridView->render());
     }
 
     public function testShowFooter(): void
@@ -867,7 +867,7 @@ final class GridViewTest extends TestCase
         </nav>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($gridView->render()));
+        $this->assertEqualsHTML($html, $gridView->render());
     }
 
     public function testSummaryOptions(): void
@@ -897,7 +897,7 @@ final class GridViewTest extends TestCase
         </table>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($gridView->render()));
+        $this->assertEqualsWithoutLE($html, $gridView->render());
     }
 
     public function testShowOnEmpty(): void
@@ -912,7 +912,7 @@ final class GridViewTest extends TestCase
         $html = <<<'HTML'
         <div id="w1-gridview" class="grid-view"><div class="empty">No results found.</div></div>
         HTML;
-        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($gridView->render()));
+        $this->assertEqualsWithoutLE($html, $gridView->render());
     }
 
     public function testTableOptions(): void
@@ -948,6 +948,6 @@ final class GridViewTest extends TestCase
         </nav>
         </div>
         HTML;
-        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($gridView->render()));
+        $this->assertEqualsHTML($html, $gridView->render());
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -80,6 +80,11 @@ class TestCase extends \PHPUnit\Framework\TestCase
         );
     }
 
+    protected function removeLE(string $value): string
+    {
+        return str_replace(["\r", "\n"], "", $value);
+    }
+
     /**
      * Asserting two strings equality ignoring line endings.
      *

--- a/tests/Widget/LinkPagerTest.php
+++ b/tests/Widget/LinkPagerTest.php
@@ -15,7 +15,7 @@ final class LinkPagerTest extends TestCase
         LinkPager::counter(0);
 
         $linkPager = LinkPager::widget()
-            ->activePageCssClass('test-active')
+            ->activeButtonAttributes(['class' => 'test-active'])
             ->paginator($this->createOffsetPaginator()->withPageSize(5));
 
         $html = <<<'HTML'
@@ -27,9 +27,8 @@ final class LinkPagerTest extends TestCase
         <li class="page-item"><a class="page-link" href data-page="2">Next Page</a></li>
         </ul>
         </nav>
-
         HTML;
-        $this->assertEqualsWithoutLE($html, $linkPager->render());
+        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($linkPager->render()));
     }
 
     public function testButtonsContainerAttributes(): void
@@ -37,7 +36,7 @@ final class LinkPagerTest extends TestCase
         LinkPager::counter(0);
 
         $linkPager = LinkPager::widget()
-            ->buttonsContainerAttributes(['class' => 'text-danger'])
+            ->buttonsContainerAttributes(['class' => 'text-danger page-item'])
             ->paginator($this->createOffsetPaginator()->withPageSize(5));
 
         $html = <<<'HTML'
@@ -49,7 +48,6 @@ final class LinkPagerTest extends TestCase
         <li class="page-item"><a class="page-link" href data-page="2">Next Page</a></li>
         </ul>
         </nav>
-
         HTML;
         $this->assertEqualsWithoutLE($html, $linkPager->render());
     }
@@ -71,7 +69,6 @@ final class LinkPagerTest extends TestCase
         <li class="page-item"><a class="page-link" href data-page="2">Next Page</a></li>
         </ul>
         </nav>
-
         HTML;
         $this->assertEqualsWithoutLE($html, $linkPager->render());
     }
@@ -81,7 +78,7 @@ final class LinkPagerTest extends TestCase
         LinkPager::counter(0);
 
         $linkPager = LinkPager::widget()
-            ->disabledPageCssClass('test-disabled')
+            ->disabledButtonAttributes(['class' => 'test-disabled'])
             ->paginator($this->createOffsetPaginator()->withPageSize(5));
 
 
@@ -94,7 +91,6 @@ final class LinkPagerTest extends TestCase
         <li class="page-item"><a class="page-link" href data-page="2">Next Page</a></li>
         </ul>
         </nav>
-
         HTML;
         $this->assertEqualsWithoutLE($html, $linkPager->render());
     }
@@ -104,23 +100,23 @@ final class LinkPagerTest extends TestCase
         LinkPager::counter(0);
 
         $linkPager = LinkPager::widget()
-            ->firstPageCssClass('test-class')
-            ->firstPageLabel('First')
+            ->firstPageAttributes([
+                'class' => 'test-class',
+            ])->firstPageLabel('First')
             ->paginator($this->createOffsetPaginator()->withPageSize(5));
 
         $html = <<<'HTML'
         <nav aria-label="Pagination">
         <ul class="pagination justify-content-center mt-4">
-        <li class="test-class"><a class="page-link" href data-page="1">First</a></li>
+        <li class="test-class disabled"><a class="page-link" href data-page="1" aria-disabled="true" tabindex="-1">First</a></li>
         <li class="page-item disabled"><a class="page-link" href data-page="1" aria-disabled="true" tabindex="-1">Previous</a></li>
         <li class="page-item active"><a class="page-link" href data-page="1">1</a></li>
         <li class="page-item"><a class="page-link" href data-page="2">2</a></li>
         <li class="page-item"><a class="page-link" href data-page="2">Next Page</a></li>
         </ul>
         </nav>
-
         HTML;
-        $this->assertEqualsWithoutLE($html, $linkPager->render());
+        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($linkPager->render()));
     }
 
     public function testCssFrameworkException(): void
@@ -145,8 +141,9 @@ final class LinkPagerTest extends TestCase
         LinkPager::counter(0);
 
         $linkPager = LinkPager::widget()
-            ->lastPageCssClass('test-class')
-            ->lastPageLabel('Last')
+            ->lastPageAttributes([
+                'class' => 'test-class'
+            ])->lastPageLabel('Last')
             ->paginator($this->createOffsetPaginator()->withPageSize(5));
 
         $html = <<<'HTML'
@@ -159,9 +156,8 @@ final class LinkPagerTest extends TestCase
         <li class="test-class"><a class="page-link" href data-page="2">Last</a></li>
         </ul>
         </nav>
-
         HTML;
-        $this->assertEqualsWithoutLE($html, $linkPager->render());
+        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($linkPager->render()));
     }
 
     public function testLinkAttributes(): void
@@ -181,7 +177,6 @@ final class LinkPagerTest extends TestCase
         <li class="page-item"><a class="test-class" href data-page="2">Next Page</a></li>
         </ul>
         </nav>
-
         HTML;
         $this->assertEqualsWithoutLE($html, $linkPager->render());
     }
@@ -202,7 +197,6 @@ final class LinkPagerTest extends TestCase
         <li class="page-item"><a class="page-link" href data-page="2">Next Page</a></li>
         </ul>
         </nav>
-
         HTML;
         $this->assertEqualsWithoutLE($html, $linkPager->render());
     }
@@ -212,7 +206,7 @@ final class LinkPagerTest extends TestCase
         LinkPager::counter(0);
 
         $linkPager = LinkPager::widget()
-            ->nextPageCssClass('test-class')
+            ->nextPageAttributes(['class' => 'test-class'])
             ->nextPageLabel('Next Page')
             ->paginator($this->createOffsetPaginator()->withPageSize(5));
 
@@ -225,7 +219,6 @@ final class LinkPagerTest extends TestCase
         <li class="test-class"><a class="page-link" href data-page="2">Next Page</a></li>
         </ul>
         </nav>
-
         HTML;
         $this->assertEqualsWithoutLE($html, $linkPager->render());
     }
@@ -247,7 +240,6 @@ final class LinkPagerTest extends TestCase
         <li class="page-item"><a class="page-link" href data-page="2">Next Page</a></li>
         </ul>
         </nav>
-
         HTML;
         $this->assertEqualsWithoutLE($html, $linkPager->render());
     }
@@ -257,7 +249,7 @@ final class LinkPagerTest extends TestCase
         LinkPager::counter(0);
 
         $linkPager = LinkPager::widget()
-            ->pageCssClass('test-class')
+            ->buttonsContainerAttributes(['class' => 'test-class'])
             ->paginator($this->createOffsetPaginator()->withPageSize(5));
 
         $html = <<<'HTML'
@@ -269,7 +261,6 @@ final class LinkPagerTest extends TestCase
         <li class="page-item"><a class="page-link" href data-page="2">Next Page</a></li>
         </ul>
         </nav>
-
         HTML;
         $this->assertEqualsWithoutLE($html, $linkPager->render());
     }
@@ -280,7 +271,7 @@ final class LinkPagerTest extends TestCase
 
         $linkPager = LinkPager::widget()
             ->prevPageLabel('Previous')
-            ->prevPageCssClass('test-class')
+            ->prevPageAttributes(['class' => 'test-class'])
             ->paginator($this->createOffsetPaginator()->withPageSize(5));
 
         $html = <<<'HTML'
@@ -292,7 +283,6 @@ final class LinkPagerTest extends TestCase
         <li class="page-item"><a class="page-link" href data-page="2">Next Page</a></li>
         </ul>
         </nav>
-
         HTML;
         $this->assertEqualsWithoutLE($html, $linkPager->render());
     }
@@ -321,8 +311,36 @@ final class LinkPagerTest extends TestCase
         <li class="page-item"><a class="page-link" href data-page="2">Next Page</a></li>
         </ul>
         </nav>
-
         HTML;
+        $this->assertEqualsWithoutLE($html, $linkPager->render());
+    }
+
+    public function testEncode(): void
+    {
+        $linkPager = LinkPager::widget()
+            ->paginator($this->createOffsetPaginator()->withPageSize(5))
+            ->prevPageLabel('<span aria-hidden="true">&laquo;</span>')
+            ->nextPageLabel('<span aria-hidden="true">&raquo;</span>')
+            ->prevPageAttributes([
+                'class' => 'page-item',
+                'encode' => false,
+            ])
+            ->nextPageAttributes([
+                'class' => 'page-item',
+                'encode' => false,
+            ]);
+
+        $html = <<<'HTML'
+        <nav aria-label="Pagination">
+        <ul class="pagination justify-content-center mt-4">
+        <li class="page-item disabled"><a class="page-link" href data-page="1" aria-disabled="true" tabindex="-1"><span aria-hidden="true">&laquo;</span></a></li>
+        <li class="page-item active"><a class="page-link" href data-page="1">1</a></li>
+        <li class="page-item"><a class="page-link" href data-page="2">2</a></li>
+        <li class="page-item"><a class="page-link" href data-page="2"><span aria-hidden="true">&raquo;</span></a></li>
+        </ul>
+        </nav>
+        HTML;
+
         $this->assertEqualsWithoutLE($html, $linkPager->render());
     }
 }

--- a/tests/Widget/LinkPagerTest.php
+++ b/tests/Widget/LinkPagerTest.php
@@ -28,7 +28,7 @@ final class LinkPagerTest extends TestCase
         </ul>
         </nav>
         HTML;
-        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($linkPager->render()));
+        $this->assertEqualsHTML($html, $linkPager->render());
     }
 
     public function testButtonsContainerAttributes(): void
@@ -49,7 +49,7 @@ final class LinkPagerTest extends TestCase
         </ul>
         </nav>
         HTML;
-        $this->assertEqualsWithoutLE($html, $linkPager->render());
+        $this->assertEqualsHTML($html, $linkPager->render());
     }
 
     public function testDisableCurrentPageButton(): void
@@ -70,7 +70,7 @@ final class LinkPagerTest extends TestCase
         </ul>
         </nav>
         HTML;
-        $this->assertEqualsWithoutLE($html, $linkPager->render());
+        $this->assertEqualsHTML($html, $linkPager->render());
     }
 
     public function testDisabledPageCssClass(): void
@@ -92,7 +92,7 @@ final class LinkPagerTest extends TestCase
         </ul>
         </nav>
         HTML;
-        $this->assertEqualsWithoutLE($html, $linkPager->render());
+        $this->assertEqualsHTML($html, $linkPager->render());
     }
 
     public function testFirstPageLabel(): void
@@ -116,7 +116,7 @@ final class LinkPagerTest extends TestCase
         </ul>
         </nav>
         HTML;
-        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($linkPager->render()));
+        $this->assertEqualsHTML($html, $linkPager->render());
     }
 
     public function testCssFrameworkException(): void
@@ -157,7 +157,7 @@ final class LinkPagerTest extends TestCase
         </ul>
         </nav>
         HTML;
-        $this->assertEqualsWithoutLE($this->removeLE($html), $this->removeLE($linkPager->render()));
+        $this->assertEqualsHTML($html, $linkPager->render());
     }
 
     public function testLinkAttributes(): void
@@ -178,7 +178,7 @@ final class LinkPagerTest extends TestCase
         </ul>
         </nav>
         HTML;
-        $this->assertEqualsWithoutLE($html, $linkPager->render());
+        $this->assertEqualsHTML($html, $linkPager->render());
     }
 
     public function testMaxButtonCount(): void
@@ -198,7 +198,7 @@ final class LinkPagerTest extends TestCase
         </ul>
         </nav>
         HTML;
-        $this->assertEqualsWithoutLE($html, $linkPager->render());
+        $this->assertEqualsHTML($html, $linkPager->render());
     }
 
     public function testNextPageLabel(): void
@@ -220,7 +220,7 @@ final class LinkPagerTest extends TestCase
         </ul>
         </nav>
         HTML;
-        $this->assertEqualsWithoutLE($html, $linkPager->render());
+        $this->assertEqualsHTML($html, $linkPager->render());
     }
 
     public function testNavAttributes(): void
@@ -241,7 +241,7 @@ final class LinkPagerTest extends TestCase
         </ul>
         </nav>
         HTML;
-        $this->assertEqualsWithoutLE($html, $linkPager->render());
+        $this->assertEqualsHTML($html, $linkPager->render());
     }
 
     public function testPageCssClass(): void
@@ -262,7 +262,7 @@ final class LinkPagerTest extends TestCase
         </ul>
         </nav>
         HTML;
-        $this->assertEqualsWithoutLE($html, $linkPager->render());
+        $this->assertEqualsHTML($html, $linkPager->render());
     }
 
     public function testPrevPageLabel(): void
@@ -284,7 +284,7 @@ final class LinkPagerTest extends TestCase
         </ul>
         </nav>
         HTML;
-        $this->assertEqualsWithoutLE($html, $linkPager->render());
+        $this->assertEqualsHTML($html, $linkPager->render());
     }
 
     public function testPaginatorEmpty(): void
@@ -312,7 +312,7 @@ final class LinkPagerTest extends TestCase
         </ul>
         </nav>
         HTML;
-        $this->assertEqualsWithoutLE($html, $linkPager->render());
+        $this->assertEqualsHTML($html, $linkPager->render());
     }
 
     public function testEncode(): void
@@ -341,6 +341,6 @@ final class LinkPagerTest extends TestCase
         </nav>
         HTML;
 
-        $this->assertEqualsWithoutLE($html, $linkPager->render());
+        $this->assertEqualsHTML($html, $linkPager->render());
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ✔️
| Breaks BC?    | ✔️
| Fixed issues  | #73

1. Separate **requestArguments** and **requestQueryParams** as in last `UrlGenerator::generate*` methods
2. Remove unimportant LE from LinkPager output
3. New test method `assertEqualsHTML`