### PR TITLE
Add setters for `table` and `tbody` attributes in `GridView`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,8 @@
         },
         "config-plugin": {
             "params": "params.php",
-            "di": "di.php"
+            "di": "di.php",
+            "widgets-themes": "widgets-themes.php"
         }
     },
     "autoload": {

--- a/config/widgets-themes.php
+++ b/config/widgets-themes.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+use Yiisoft\Yii\DataView\GridView;
+
+return [
+    'bootstrap5' => [
+        GridView::class => [
+            'tableClass' => ['table'],
+        ],
+    ],
+];

--- a/config/widgets-themes.php
+++ b/config/widgets-themes.php
@@ -7,7 +7,8 @@ use Yiisoft\Yii\DataView\GridView;
 return [
     'bootstrap5' => [
         GridView::class => [
-            'tableClass()' => ['table'],
+            'tableClass()' => ['table table-bordered'],
+            'tbodyClass()' => ['table-group-divider']
         ],
     ],
 ];

--- a/config/widgets-themes.php
+++ b/config/widgets-themes.php
@@ -7,7 +7,7 @@ use Yiisoft\Yii\DataView\GridView;
 return [
     'bootstrap5' => [
         GridView::class => [
-            'tableClass' => ['table'],
+            'tableClass()' => ['table'],
         ],
     ],
 ];

--- a/src/GridView.php
+++ b/src/GridView.php
@@ -51,7 +51,7 @@ final class GridView extends BaseListView
     private bool $headerTableEnabled = true;
     private array $headerRowAttributes = [];
     private array $rowAttributes = [];
-    private array $tableAttributes = ['class' => 'table'];
+    private array $tableAttributes = [];
 
     public function __construct(
         private CurrentRoute $currentRoute,
@@ -257,15 +257,38 @@ final class GridView extends BaseListView
     }
 
     /**
-     * Return new instance with the HTML attributes for the table.
+     * Return new instance with the HTML attributes for the table tag.
      *
-     * @param array $values Attribute values indexed by attribute names.
+     * @param array $attributes The tag attributes in terms of name-value pairs.
      */
-    public function tableAttributes(array $values): self
+    public function tableAttributes(array $attributes): self
     {
         $new = clone $this;
-        $new->tableAttributes = $values;
+        $new->tableAttributes = $attributes;
+        return $new;
+    }
 
+    /**
+     * Add one or more CSS classes to the table tag.
+     *
+     * @param string|null ...$class One or many CSS classes.
+     */
+    public function addTableClass(?string ...$class): self
+    {
+        $new = clone $this;
+        Html::addCssClass($new->tableAttributes, $class);
+        return $new;
+    }
+
+    /**
+     * Replace current table tag CSS classes with a new set of classes.
+     *
+     * @param string|null ...$class One or many CSS classes.
+     */
+    public function tableClass(?string ...$class): static
+    {
+        $new = clone $this;
+        $new->tableAttributes['class'] = array_filter($class, static fn ($c) => $c !== null);
         return $new;
     }
 

--- a/src/GridView.php
+++ b/src/GridView.php
@@ -499,7 +499,7 @@ final class GridView extends BaseListView
         $index = 0;
         foreach ($this->getItems() as $key => $value) {
             if ($this->beforeRow !== null) {
-                /** @var array */
+                /** @var string */
                 $row = call_user_func($this->beforeRow, $value, $key, $index, $this);
 
                 if (!empty($row)) {
@@ -510,10 +510,10 @@ final class GridView extends BaseListView
             $rows[] = $this->renderTableRow($columns, $value, $key, $index);
 
             if ($this->afterRow !== null) {
-                /** @psalm-var array<array-key,string> */
+                /** @var string */
                 $row = call_user_func($this->afterRow, $value, $key, $index, $this);
 
-                if ($row !== []) {
+                if (!empty($row)) {
                     $rows[] = $row;
                 }
             }
@@ -529,8 +529,8 @@ final class GridView extends BaseListView
                 ->render();
         }
 
-        /** @psalm-var array<array-key,string> $rows */
-        return Html::tag('tbody', PHP_EOL . implode(PHP_EOL, $rows) . PHP_EOL)->encode(false)->render();
+        $tbody = Html::tbody($this->tbodyAttributes);
+        return $tbody->open() . PHP_EOL . implode(PHP_EOL, $rows) . PHP_EOL . $tbody->close();
     }
 
     /**

--- a/src/GridView.php
+++ b/src/GridView.php
@@ -12,7 +12,6 @@ use Yiisoft\Factory\NotFoundException;
 use Yiisoft\Html\Html;
 use Yiisoft\Html\Tag\Col;
 use Yiisoft\Html\Tag\Colgroup;
-use Yiisoft\Html\Tag\Tbody;
 use Yiisoft\Html\Tag\Td;
 use Yiisoft\Html\Tag\Tr;
 use Yiisoft\Router\CurrentRoute;
@@ -52,6 +51,7 @@ final class GridView extends BaseListView
     private array $headerRowAttributes = [];
     private array $rowAttributes = [];
     private array $tableAttributes = [];
+    private array $tbodyAttributes = [];
 
     public function __construct(
         private CurrentRoute $currentRoute,
@@ -257,7 +257,7 @@ final class GridView extends BaseListView
     }
 
     /**
-     * Return new instance with the HTML attributes for the table tag.
+     * Return new instance with the HTML attributes for the `table` tag.
      *
      * @param array $attributes The tag attributes in terms of name-value pairs.
      */
@@ -269,7 +269,7 @@ final class GridView extends BaseListView
     }
 
     /**
-     * Add one or more CSS classes to the table tag.
+     * Add one or more CSS classes to the `table` tag.
      *
      * @param string|null ...$class One or many CSS classes.
      */
@@ -281,7 +281,7 @@ final class GridView extends BaseListView
     }
 
     /**
-     * Replace current table tag CSS classes with a new set of classes.
+     * Replace current `table` tag CSS classes with a new set of classes.
      *
      * @param string|null ...$class One or many CSS classes.
      */
@@ -289,6 +289,42 @@ final class GridView extends BaseListView
     {
         $new = clone $this;
         $new->tableAttributes['class'] = array_filter($class, static fn ($c) => $c !== null);
+        return $new;
+    }
+
+    /**
+     * Return new instance with the HTML attributes for the `tbody` tag.
+     *
+     * @param array $attributes The tag attributes in terms of name-value pairs.
+     */
+    public function tbodyAttributes(array $attributes): self
+    {
+        $new = clone $this;
+        $new->tbodyAttributes = $attributes;
+        return $new;
+    }
+
+    /**
+     * Add one or more CSS classes to the `tbody` tag.
+     *
+     * @param string|null ...$class One or many CSS classes.
+     */
+    public function addTbodyClass(?string ...$class): self
+    {
+        $new = clone $this;
+        Html::addCssClass($new->tbodyAttributes, $class);
+        return $new;
+    }
+
+    /**
+     * Replace current `tbody` tag CSS classes with a new set of classes.
+     *
+     * @param string|null ...$class One or many CSS classes.
+     */
+    public function tbodyClass(?string ...$class): static
+    {
+        $new = clone $this;
+        $new->tbodyAttributes['class'] = array_filter($class, static fn ($c) => $c !== null);
         return $new;
     }
 
@@ -488,7 +524,7 @@ final class GridView extends BaseListView
         if ($rows === [] && $this->emptyText !== '') {
             $colspan = count($columns);
 
-            return Tbody::tag()
+            return Html::tbody($this->tbodyAttributes)
                 ->rows(Tr::tag()->cells($this->renderEmpty($colspan)))
                 ->render();
         }

--- a/tests/Column/ActionColumnTest.php
+++ b/tests/Column/ActionColumnTest.php
@@ -36,7 +36,7 @@ final class ActionColumnTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <thead>
             <tr>
             <th>Actions</th>
@@ -84,7 +84,7 @@ final class ActionColumnTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <thead>
             <tr>
             <th>Actions</th>
@@ -133,7 +133,7 @@ final class ActionColumnTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <thead>
             <tr>
             <th>Actions</th>
@@ -188,7 +188,7 @@ final class ActionColumnTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <thead>
             <tr>
             <th>Actions</th>
@@ -233,7 +233,7 @@ final class ActionColumnTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <thead>
             <tr>
             <th>Actions</th>
@@ -286,7 +286,7 @@ final class ActionColumnTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <thead>
             <tr>
             <th>test.label</th>
@@ -331,7 +331,7 @@ final class ActionColumnTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <thead>
             <tr>
             <th>Ενέργειες</th>
@@ -376,7 +376,7 @@ final class ActionColumnTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <thead>
             <tr>
             <th class="test.class">test.label</th>
@@ -421,7 +421,7 @@ final class ActionColumnTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <thead>
             <tr>
             <th>Actions</th>
@@ -466,7 +466,7 @@ final class ActionColumnTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <thead>
             <tr></tr>
             </thead>
@@ -497,7 +497,7 @@ final class ActionColumnTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <thead>
             <tr>
             <th>Actions</th>
@@ -550,7 +550,7 @@ final class ActionColumnTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <thead>
             <tr>
             <th>Id</th>
@@ -605,7 +605,7 @@ final class ActionColumnTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <thead>
             <tr>
             <th>Actions</th>
@@ -650,7 +650,7 @@ final class ActionColumnTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <thead>
             <tr>
             <th>Actions</th>
@@ -701,7 +701,7 @@ final class ActionColumnTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <thead>
             <tr>
             <th>Actions</th>
@@ -746,7 +746,7 @@ final class ActionColumnTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <thead>
             <tr>
             <th>Actions</th>
@@ -791,7 +791,7 @@ final class ActionColumnTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <thead>
             <tr>
             <th>Actions</th>

--- a/tests/Column/CheckboxColumnTest.php
+++ b/tests/Column/CheckboxColumnTest.php
@@ -35,7 +35,7 @@ final class CheckboxColumnTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <thead>
             <tr>
             <th>Id</th>
@@ -84,7 +84,7 @@ final class CheckboxColumnTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <thead>
             <tr>
             <th>Id</th>
@@ -135,7 +135,7 @@ final class CheckboxColumnTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <thead>
             <tr>
             <th>Id</th>
@@ -182,7 +182,7 @@ final class CheckboxColumnTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <thead>
             <tr>
             <th>Id</th>
@@ -229,7 +229,7 @@ final class CheckboxColumnTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <thead>
             <tr>
             <th>Id</th>
@@ -276,7 +276,7 @@ final class CheckboxColumnTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <thead>
             <tr>
             <th>Id</th>
@@ -323,7 +323,7 @@ final class CheckboxColumnTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <thead>
             <tr>
             <th>Id</th>
@@ -370,7 +370,7 @@ final class CheckboxColumnTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <thead>
             <tr>
             <th>Id</th>
@@ -417,7 +417,7 @@ final class CheckboxColumnTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <thead>
             <tr>
             <th>Id</th>
@@ -461,7 +461,7 @@ final class CheckboxColumnTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <thead>
             <tr>
             <th>Id</th>

--- a/tests/Column/DataColumnFilterTest.php
+++ b/tests/Column/DataColumnFilterTest.php
@@ -74,7 +74,7 @@ final class DataColumnFilterTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <thead>
             <tr>
             <th>Id</th>
@@ -121,7 +121,7 @@ final class DataColumnFilterTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <thead>
             <tr>
             <th>Id</th>
@@ -173,7 +173,7 @@ final class DataColumnFilterTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <thead>
             <tr>
             <th>Id</th>
@@ -225,7 +225,7 @@ final class DataColumnFilterTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <thead>
             <tr>
             <th>Id</th>
@@ -277,7 +277,7 @@ final class DataColumnFilterTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <thead>
             <tr>
             <th>Id</th>
@@ -333,7 +333,7 @@ final class DataColumnFilterTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <thead>
             <tr>
             <th>Id</th>
@@ -385,7 +385,7 @@ final class DataColumnFilterTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <thead>
             <tr>
             <th>Id</th>
@@ -432,7 +432,7 @@ final class DataColumnFilterTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <thead>
             <tr>
             <th>Id</th>
@@ -497,7 +497,7 @@ final class DataColumnFilterTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <thead>
             <tr class="filters">
             <th class="text-center" style="width:60px"><input type="text" name="searchModel[id]" value="0" maxlength="5"></th>
@@ -556,7 +556,7 @@ final class DataColumnFilterTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <thead>
             <tr>
             <th>Id</th>
@@ -607,7 +607,7 @@ final class DataColumnFilterTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <thead>
             <tr>
             <th>Id</th>
@@ -666,7 +666,7 @@ final class DataColumnFilterTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <thead>
             <tr>
             <th>Id</th>
@@ -713,7 +713,7 @@ final class DataColumnFilterTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <thead>
             <tr>
             <th>Id</th>
@@ -771,7 +771,7 @@ final class DataColumnFilterTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <thead>
             <tr>
             <th>Id</th>
@@ -825,7 +825,7 @@ final class DataColumnFilterTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <thead>
             <tr>
             <th>Id</th>
@@ -879,7 +879,7 @@ final class DataColumnFilterTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <thead>
             <tr>
             <th>Id</th>
@@ -933,7 +933,7 @@ final class DataColumnFilterTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <thead>
             <tr>
             <th>Id</th>
@@ -987,7 +987,7 @@ final class DataColumnFilterTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <thead>
             <tr>
             <th>Id</th>

--- a/tests/Column/DataColumnTest.php
+++ b/tests/Column/DataColumnTest.php
@@ -34,7 +34,7 @@ final class DataColumnTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <thead>
             <tr>
             <th>Id</th>
@@ -81,7 +81,7 @@ final class DataColumnTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <thead>
             <tr>
             <th>Id</th>
@@ -130,7 +130,7 @@ final class DataColumnTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <thead>
             <tr>
             <th>Id</th>
@@ -177,7 +177,7 @@ final class DataColumnTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <thead>
             <tr>
             <th>Id</th>
@@ -220,7 +220,7 @@ final class DataColumnTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <thead>
             <tr>
             <th>test.id</th>
@@ -263,7 +263,7 @@ final class DataColumnTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <thead>
             <tr>
             <th>Id</th>
@@ -306,7 +306,7 @@ final class DataColumnTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <thead>
             <tr>
             <th class="test.class">test.id</th>
@@ -355,7 +355,7 @@ final class DataColumnTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <thead>
             <tr>
             <th><a href="/admin/manage/1/5?sort=id" data-sort="id">id</a></th>
@@ -402,7 +402,7 @@ final class DataColumnTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <thead>
             <tr>
             <th><a class="asc" href="/admin/manage?page=1&amp;pagesize=10&amp;sort=-id%2Cname" data-sort="-id,name">Id <i class="bi bi-sort-alpha-up"></i></a></th>
@@ -445,7 +445,7 @@ final class DataColumnTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <thead>
             <tr>
             <th>Id</th>
@@ -488,7 +488,7 @@ final class DataColumnTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <thead>
             <tr>
             <th>Id</th>
@@ -528,7 +528,7 @@ final class DataColumnTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <thead>
             <tr>
             <th><a class="asc" href="/admin/manage?page=1&amp;pagesize=10&amp;sort=-id%2Cname" data-sort="-id,name">Id <i class="bi bi-sort-alpha-up"></i></a></th>
@@ -571,7 +571,7 @@ final class DataColumnTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <thead>
             <tr>
             <th>Id</th>
@@ -614,7 +614,7 @@ final class DataColumnTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <thead>
             <tr>
             <th>Id</th>

--- a/tests/Column/RadioColumnTest.php
+++ b/tests/Column/RadioColumnTest.php
@@ -35,7 +35,7 @@ final class RadioColumnTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <thead>
             <tr>
             <th>Id</th>
@@ -85,7 +85,7 @@ final class RadioColumnTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <thead>
             <tr>
             <th>Id</th>
@@ -136,7 +136,7 @@ final class RadioColumnTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <thead>
             <tr>
             <th>Id</th>
@@ -183,7 +183,7 @@ final class RadioColumnTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <thead>
             <tr>
             <th>Id</th>
@@ -230,7 +230,7 @@ final class RadioColumnTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <thead>
             <tr>
             <th>Id</th>
@@ -277,7 +277,7 @@ final class RadioColumnTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <thead>
             <tr>
             <th>Id</th>
@@ -324,7 +324,7 @@ final class RadioColumnTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <thead>
             <tr>
             <th>Id</th>
@@ -371,7 +371,7 @@ final class RadioColumnTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <thead>
             <tr>
             <th>Id</th>
@@ -415,7 +415,7 @@ final class RadioColumnTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <thead>
             <tr>
             <th>Id</th>

--- a/tests/GridView/BaseTest.php
+++ b/tests/GridView/BaseTest.php
@@ -35,7 +35,7 @@ final class BaseTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <thead>
             <tr>
             <th>#</th>
@@ -92,7 +92,7 @@ final class BaseTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <colgroup>
             <col class="text-primary">
             <col class="bg-primary">
@@ -145,7 +145,7 @@ final class BaseTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <colgroup>
             <col>
             <col>
@@ -203,7 +203,7 @@ final class BaseTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <thead>
             <tr>
             <th>Id</th>
@@ -256,7 +256,7 @@ final class BaseTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <thead>
             <tr>
             <th>Id</th>
@@ -291,7 +291,7 @@ final class BaseTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <thead>
             <tr>
             <th>#</th>
@@ -333,7 +333,7 @@ final class BaseTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <thead>
             <tr>
             <th>#</th>
@@ -388,7 +388,7 @@ final class BaseTest extends TestCase
             <<<HTML
             <div>List of users</div>
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <thead>
             <tr>
             <th>#</th>
@@ -441,7 +441,7 @@ final class BaseTest extends TestCase
             <<<HTML
             <div id="w1-grid">
             <div>List of users</div>
-            <table class="table">
+            <table>
             <thead>
             <tr>
             <th>#</th>
@@ -495,7 +495,7 @@ final class BaseTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <thead>
             <tr class="text-primary">
             <th>#</th>
@@ -547,7 +547,7 @@ final class BaseTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <tbody>
             <tr>
             <td data-label="#">1</td>
@@ -591,7 +591,7 @@ final class BaseTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <thead>
             <tr>
             <th>#</th>
@@ -632,7 +632,7 @@ final class BaseTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <thead>
             <tr>
             <th>#</th>
@@ -675,7 +675,7 @@ final class BaseTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <thead>
             <tr>
             <th>#</th>

--- a/tests/GridView/TranslatorTest.php
+++ b/tests/GridView/TranslatorTest.php
@@ -58,7 +58,7 @@ final class TranslatorTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <thead>
             <tr>
             <th>#</th>
@@ -101,7 +101,7 @@ final class TranslatorTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <thead>
             <tr>
             <th>#</th>
@@ -144,7 +144,7 @@ final class TranslatorTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <thead>
             <tr>
             <th>#</th>
@@ -185,7 +185,7 @@ final class TranslatorTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <thead>
             <tr>
             <th>#</th>
@@ -238,7 +238,7 @@ final class TranslatorTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <thead>
             <tr>
             <th>#</th>
@@ -291,7 +291,7 @@ final class TranslatorTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <thead>
             <tr>
             <th>#</th>

--- a/tests/Pagination/KeysetPaginationBaseTest.php
+++ b/tests/Pagination/KeysetPaginationBaseTest.php
@@ -47,7 +47,7 @@ final class KeysetPaginationBaseTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <thead>
             <tr></tr>
             </thead>
@@ -80,7 +80,7 @@ final class KeysetPaginationBaseTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <thead>
             <tr>
             <th><a class="asc" href="/admin/manage?page=0&amp;pagesize=5&amp;sort=-id%2Cname" data-sort="-id,name">Id <i class="bi bi-sort-alpha-up"></i></a></th>
@@ -142,7 +142,7 @@ final class KeysetPaginationBaseTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <thead>
             <tr>
             <th><a class="asc" href="/admin/manage?page=0&amp;pagesize=5&amp;sort=-id%2Cname" data-sort="-id,name">Id <i class="bi bi-sort-alpha-up"></i></a></th>
@@ -204,7 +204,7 @@ final class KeysetPaginationBaseTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <thead>
             <tr>
             <th><a class="asc" href="/admin/manage?page=0&amp;pagesize=5&amp;sort=-id%2Cname" data-sort="-id,name">Id <i class="bi bi-sort-alpha-up"></i></a></th>
@@ -251,7 +251,7 @@ final class KeysetPaginationBaseTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <thead>
             <tr>
             <th><a class="asc" href="/admin/manage?page=0&amp;pagesize=5&amp;sort=-id%2Cname" data-sort="-id,name">Id <i class="bi bi-sort-alpha-up"></i></a></th>
@@ -313,7 +313,7 @@ final class KeysetPaginationBaseTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <thead>
             <tr>
             <th><a class="asc" href="/admin/manage?page=0&amp;pagesize=5&amp;sort=-id%2Cname" data-sort="-id,name">Id <i class="bi bi-sort-alpha-up"></i></a></th>

--- a/tests/Pagination/OffsetPaginationBaseTest.php
+++ b/tests/Pagination/OffsetPaginationBaseTest.php
@@ -31,7 +31,7 @@ final class OffsetPaginationBaseTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div id="w1-grid">
-            <table class="table">
+            <table>
             <thead>
             <tr></tr>
             </thead>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | -
