### PR TITLE
Add `RendererContainer`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,6 +42,7 @@
         "yiisoft/factory": "^1.0",
         "yiisoft/friendly-exception": "^1.0",
         "yiisoft/html": "^3.0",
+        "yiisoft/injector": "^1.2",
         "yiisoft/json": "^1.0",
         "yiisoft/router": "^3.0",
         "yiisoft/strings": "^2.0",

--- a/src/Column/Base/RendererContainer.php
+++ b/src/Column/Base/RendererContainer.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Yii\DataView\Column\Base;
+
+use Psr\Container\ContainerInterface;
+use Yiisoft\Injector\Injector;
+use Yiisoft\Yii\DataView\Column\ColumnRendererInterface;
+
+/**
+ * @internal
+ */
+final class RendererContainer
+{
+    private Injector $injector;
+
+    /**
+     * @psalm-var array<string, ColumnRendererInterface>
+     */
+    private array $cache = [];
+
+    /**
+     * @psalm-var array<string, array>
+     */
+    private array $constructorArguments = [];
+
+
+    public function __construct(ContainerInterface $dependencyContainer)
+    {
+        $this->injector = new Injector($dependencyContainer);
+    }
+
+    /**
+     * @psalm-param class-string<ColumnRendererInterface> $class
+     */
+    public function get(string $class): ColumnRendererInterface
+    {
+        if (!isset($this->cache[$class])) {
+            $this->cache[$class] = $this->injector->make($class, $this->constructorArguments[$class] ?? []);
+        }
+
+        return $this->cache[$class];
+    }
+
+    /**
+     * @psalm-param array<string, array> $constructorArguments
+     */
+    public function addConstructorArguments(array $constructorArguments): self
+    {
+        $new = clone $this;
+        foreach ($constructorArguments as $class => $arguments) {
+            $new->constructorArguments[$class] = $arguments;
+            unset($new->cache[$class]);
+        }
+        return $new;
+    }
+}

--- a/src/Column/Base/RendererContainer.php
+++ b/src/Column/Base/RendererContainer.php
@@ -25,7 +25,6 @@ final class RendererContainer
      */
     private array $constructorArguments = [];
 
-
     public function __construct(ContainerInterface $dependencyContainer)
     {
         $this->injector = new Injector($dependencyContainer);

--- a/src/Column/Base/RendererContainer.php
+++ b/src/Column/Base/RendererContainer.php
@@ -23,7 +23,7 @@ final class RendererContainer
     /**
      * @psalm-var array<string, array>
      */
-    private array $constructorArguments = [];
+    private array $configs = [];
 
     public function __construct(ContainerInterface $dependencyContainer)
     {
@@ -36,20 +36,20 @@ final class RendererContainer
     public function get(string $class): ColumnRendererInterface
     {
         if (!isset($this->cache[$class])) {
-            $this->cache[$class] = $this->injector->make($class, $this->constructorArguments[$class] ?? []);
+            $this->cache[$class] = $this->injector->make($class, $this->configs[$class] ?? []);
         }
 
         return $this->cache[$class];
     }
 
     /**
-     * @psalm-param array<string, array> $constructorArguments
+     * @psalm-param array<string, array> $configs
      */
-    public function addConstructorArguments(array $constructorArguments): self
+    public function addConfigs(array $configs): self
     {
         $new = clone $this;
-        foreach ($constructorArguments as $class => $arguments) {
-            $new->constructorArguments[$class] = $arguments;
+        foreach ($configs as $class => $config) {
+            $new->configs[$class] = $config;
             unset($new->cache[$class]);
         }
         return $new;

--- a/src/Column/ColumnInterface.php
+++ b/src/Column/ColumnInterface.php
@@ -13,6 +13,8 @@ interface ColumnInterface
      * A matching renderer name or an instance used for rendering this column.
      *
      * @return string A column renderer name.
+     *
+     * @psalm-return class-string<ColumnRendererInterface>
      */
     public function getRenderer(): string;
 

--- a/src/GridView.php
+++ b/src/GridView.php
@@ -83,12 +83,12 @@ final class GridView extends BaseListView
     }
 
     /**
-     * @psalm-param array<string, array> $arguments
+     * @psalm-param array<string, array> $configs
      */
-    public function addRendererConstructorArguments(array $arguments): self
+    public function addRendererConfigs(array $configs): self
     {
         $new = clone $this;
-        $new->rendererContainer = $this->rendererContainer->addConstructorArguments($arguments);
+        $new->rendererContainer = $this->rendererContainer->addConfigs($configs);
         return $new;
     }
 

--- a/src/GridView.php
+++ b/src/GridView.php
@@ -13,7 +13,6 @@ use Yiisoft\Data\Reader\Sort;
 use Yiisoft\Data\Reader\SortableDataInterface;
 use Yiisoft\Html\Html;
 use Yiisoft\Html\Tag\Tr;
-use Yiisoft\Injector\Injector;
 use Yiisoft\Translator\TranslatorInterface;
 use Yiisoft\Yii\DataView\Column\ActionColumn;
 use Yiisoft\Yii\DataView\Column\Base\Cell;

--- a/src/GridView.php
+++ b/src/GridView.php
@@ -13,12 +13,14 @@ use Yiisoft\Data\Reader\Sort;
 use Yiisoft\Data\Reader\SortableDataInterface;
 use Yiisoft\Html\Html;
 use Yiisoft\Html\Tag\Tr;
+use Yiisoft\Injector\Injector;
 use Yiisoft\Translator\TranslatorInterface;
 use Yiisoft\Yii\DataView\Column\ActionColumn;
 use Yiisoft\Yii\DataView\Column\Base\Cell;
 use Yiisoft\Yii\DataView\Column\Base\GlobalContext;
 use Yiisoft\Yii\DataView\Column\Base\DataContext;
 use Yiisoft\Yii\DataView\Column\Base\HeaderContext;
+use Yiisoft\Yii\DataView\Column\Base\RendererContainer;
 use Yiisoft\Yii\DataView\Column\ColumnInterface;
 use Yiisoft\Yii\DataView\Column\ColumnRendererInterface;
 use Yiisoft\Yii\DataView\Column\DataColumn;
@@ -71,11 +73,24 @@ final class GridView extends BaseListView
     private ?string $sortableLinkAscClass = null;
     private ?string $sortableLinkDescClass = null;
 
+    private RendererContainer $rendererContainer;
+
     public function __construct(
-        private ContainerInterface $columnRenderersContainer,
+        ContainerInterface $columnRenderersDependencyContainer,
         TranslatorInterface|null $translator = null,
     ) {
+        $this->rendererContainer = new RendererContainer($columnRenderersDependencyContainer);
         parent::__construct($translator);
+    }
+
+    /**
+     * @psalm-param array<string, array> $arguments
+     */
+    public function addRendererConstructorArguments(array $arguments): self
+    {
+        $new = clone $this;
+        $new->rendererContainer = $this->rendererContainer->addConstructorArguments($arguments);
+        return $new;
     }
 
     public function enableMultiSort(bool $value = true): self
@@ -584,8 +599,7 @@ final class GridView extends BaseListView
 
     private function getColumnRenderer(ColumnInterface $column): ColumnRendererInterface
     {
-        /** @var ColumnRendererInterface */
-        return $this->columnRenderersContainer->get($column->getRenderer());
+        return $this->rendererContainer->get($column->getRenderer());
     }
 
     private function getSort(?ReadableDataInterface $dataReader): ?Sort

--- a/tests/Column/ActionColumnTest.php
+++ b/tests/Column/ActionColumnTest.php
@@ -40,12 +40,6 @@ final class ActionColumnTest extends TestCase
         ['id' => 2, 'name' => 'Mary', 'age' => 21],
     ];
 
-    /**
-     * @throws InvalidConfigException
-     * @throws NotFoundException
-     * @throws NotInstantiableException
-     * @throws CircularReferenceException
-     */
     public function testContent(): void
     {
         Assert::equalsWithoutLE(

--- a/tests/Support/TestTrait.php
+++ b/tests/Support/TestTrait.php
@@ -18,6 +18,7 @@ use Yiisoft\Router\Route;
 use Yiisoft\Router\UrlGeneratorInterface;
 use Yiisoft\Widget\WidgetFactory;
 use Yiisoft\Yii\DataView\Column\ActionColumnRenderer;
+use Yiisoft\Yii\DataView\GridView;
 use Yiisoft\Yii\DataView\YiiRouter\ActionColumnUrlCreator;
 
 trait TestTrait
@@ -28,7 +29,17 @@ trait TestTrait
     protected function setUp(): void
     {
         $container = new Container(ContainerConfig::create()->withDefinitions($this->config()));
-        WidgetFactory::initialize($container, []);
+        WidgetFactory::initialize($container, [
+            GridView::class => [
+                'addRendererConstructorArguments()' => [
+                    [
+                        ActionColumnRenderer::class => [
+                            'defaultUrlCreator' => Reference::to(ActionColumnUrlCreator::class),
+                        ],
+                    ]
+                ],
+            ],
+        ]);
     }
 
     private function createOffsetPaginator(
@@ -62,11 +73,6 @@ trait TestTrait
         return [
             CurrentRoute::class => $currentRoute,
             UrlGeneratorInterface::class => Mock::urlGenerator([], $currentRoute),
-            ActionColumnRenderer::class => [
-                '__construct()' => [
-                    'defaultUrlCreator' => Reference::to(ActionColumnUrlCreator::class),
-                ],
-            ],
         ];
     }
 }

--- a/tests/Support/TestTrait.php
+++ b/tests/Support/TestTrait.php
@@ -36,7 +36,7 @@ trait TestTrait
                         ActionColumnRenderer::class => [
                             'defaultUrlCreator' => Reference::to(ActionColumnUrlCreator::class),
                         ],
-                    ]
+                    ],
                 ],
             ],
         ]);

--- a/tests/Support/TestTrait.php
+++ b/tests/Support/TestTrait.php
@@ -31,7 +31,7 @@ trait TestTrait
         $container = new Container(ContainerConfig::create()->withDefinitions($this->config()));
         WidgetFactory::initialize($container, [
             GridView::class => [
-                'addRendererConstructorArguments()' => [
+                'addRendererConfigs()' => [
                     [
                         ActionColumnRenderer::class => [
                             'defaultUrlCreator' => Reference::to(ActionColumnUrlCreator::class),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ✔️

It allow to configure renderers in widget. For example:

```php
GridView::class => [
	'addRendererConfigs()' => [
		[
			ActionColumnRenderer::class => [
				'defaultUrlCreator' => Reference::to(ActionColumnUrlCreator::class),
			],
			DataColumnRenderer::class => [
				'dateTimeFormat' => 'd.m.Y, H:i:s',
			],
		],
	],
	// ...
],
```
