### PR TITLE
Default template change proposal

### DIFF
--- a/src/DetailView.php
+++ b/src/DetailView.php
@@ -43,12 +43,12 @@ final class DetailView extends Widget
     private string $header = '';
     private string $itemTemplate = "<div{dataAttributes}>\n{label}\n{value}\n</div>";
     private array|Closure $labelAttributes = [];
-    private string $labelTag = 'span';
+    private string $labelTag = 'dt';
     private string $labelTemplate = '<{labelTag}{labelAttributes}>{label}</{labelTag}>';
-    private string $template = "<div{attributes}>\n<div{containerAttributes}>\n{header}\n{items}\n</div>\n</div>";
+    private string $template = "<div{attributes}>\n{header}<dl{containerAttributes}>\n{items}\n</dl>\n</div>";
     private array|Closure $valueAttributes = [];
     private string $valueFalse = 'false';
-    private string $valueTag = 'div';
+    private string $valueTag = 'dd';
     private string $valueTemplate = '<{valueTag}{valueAttributes}>{value}</{valueTag}>';
     private string $valueTrue = 'true';
 

--- a/src/DetailView.php
+++ b/src/DetailView.php
@@ -45,7 +45,7 @@ final class DetailView extends Widget
     private array|Closure $labelAttributes = [];
     private string $labelTag = 'dt';
     private string $labelTemplate = '<{labelTag}{labelAttributes}>{label}</{labelTag}>';
-    private string $template = "<div{attributes}>\n{header}<dl{containerAttributes}>\n{items}\n</dl>\n</div>";
+    private string $template = "<div{attributes}>\n{header}\n<dl{containerAttributes}>\n{items}\n</dl>\n</div>";
     private array|Closure $valueAttributes = [];
     private string $valueFalse = 'false';
     private string $valueTag = 'dd';

--- a/tests/DetailView/BaseTest.php
+++ b/tests/DetailView/BaseTest.php
@@ -30,20 +30,20 @@ final class BaseTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div class="test-class">
+            <dl>
             <div>
-            <div>
-            <span>id</span>
-            <div>1</div>
+            <dt>id</dt>
+            <dd>1</dd>
             </div>
             <div>
-            <span>username</span>
-            <div>tests 1</div>
+            <dt>username</dt>
+            <dd>tests 1</dd>
             </div>
             <div>
-            <span>total</span>
-            <div>10</div>
+            <dt>total</dt>
+            <dd>10</dd>
             </div>
-            </div>
+            </dl>
             </div>
             HTML,
             DetailView::widget()
@@ -69,20 +69,20 @@ final class BaseTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div>
-            <div class="test-class">
+            <dl class="test-class">
             <div>
-            <span>id</span>
-            <div>1</div>
-            </div>
-            <div>
-            <span>username</span>
-            <div>tests 1</div>
+            <dt>id</dt>
+            <dd>1</dd>
             </div>
             <div>
-            <span>total</span>
-            <div>10</div>
+            <dt>username</dt>
+            <dd>tests 1</dd>
             </div>
+            <div>
+            <dt>total</dt>
+            <dd>10</dd>
             </div>
+            </dl>
             </div>
             HTML,
             DetailView::widget()
@@ -108,20 +108,20 @@ final class BaseTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div>
-            <div>
+            <dl>
             <div class="test-class">
-            <span>id</span>
-            <div>1</div>
-            </div>
-            <div class="test-class">
-            <span>username</span>
-            <div>tests 1</div>
+            <dt>id</dt>
+            <dd>1</dd>
             </div>
             <div class="test-class">
-            <span>total</span>
-            <div>10</div>
+            <dt>username</dt>
+            <dd>tests 1</dd>
             </div>
+            <div class="test-class">
+            <dt>total</dt>
+            <dd>10</dd>
             </div>
+            </dl>
             </div>
             HTML,
             DetailView::widget()
@@ -147,21 +147,21 @@ final class BaseTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div>
-            <div>
             Test header
+            <dl>
             <div>
-            <span>id</span>
-            <div>1</div>
-            </div>
-            <div>
-            <span>username</span>
-            <div>tests 1</div>
+            <dt>id</dt>
+            <dd>1</dd>
             </div>
             <div>
-            <span>total</span>
-            <div>10</div>
+            <dt>username</dt>
+            <dd>tests 1</dd>
             </div>
+            <div>
+            <dt>total</dt>
+            <dd>10</dd>
             </div>
+            </dl>
             </div>
             HTML,
             DetailView::widget()
@@ -187,20 +187,20 @@ final class BaseTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div>
+            <dl>
             <div>
-            <div>
-            <span class="test-label">id</span>
-            <div>1</div>
+            <dt class="test-label">id</dt>
+            <dd>1</dd>
             </div>
             <div>
-            <span class="test-label">username</span>
-            <div>tests 1</div>
+            <dt class="test-label">username</dt>
+            <dd>tests 1</dd>
             </div>
             <div>
-            <span class="test-label">total</span>
-            <div>10</div>
+            <dt class="test-label">total</dt>
+            <dd>10</dd>
             </div>
-            </div>
+            </dl>
             </div>
             HTML,
             DetailView::widget()
@@ -226,20 +226,20 @@ final class BaseTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div>
-            <div>
+            <dl>
             <div>
             <p>id</p>
-            <div>1</div>
+            <dd>1</dd>
             </div>
             <div>
             <p>username</p>
-            <div>tests 1</div>
+            <dd>tests 1</dd>
             </div>
             <div>
             <p>total</p>
-            <div>10</div>
+            <dd>10</dd>
             </div>
-            </div>
+            </dl>
             </div>
             HTML,
             DetailView::widget()
@@ -276,20 +276,20 @@ final class BaseTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div>
+            <dl>
             <div>
-            <div>
-            <span>id</span>
-            <div class="test-value">1</div>
+            <dt>id</dt>
+            <dd class="test-value">1</dd>
             </div>
             <div>
-            <span>username</span>
-            <div class="test-value">tests 1</div>
+            <dt>username</dt>
+            <dd class="test-value">tests 1</dd>
             </div>
             <div>
-            <span>total</span>
-            <div class="test-value">10</div>
+            <dt>total</dt>
+            <dd class="test-value">10</dd>
             </div>
-            </div>
+            </dl>
             </div>
             HTML,
             DetailView::widget()
@@ -315,20 +315,20 @@ final class BaseTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div>
+            <dl>
             <div>
-            <div>
-            <span>id</span>
-            <div>1</div>
+            <dt>id</dt>
+            <dd>1</dd>
             </div>
             <div>
-            <span>username</span>
-            <div>guess</div>
+            <dt>username</dt>
+            <dd>guess</dd>
             </div>
             <div>
-            <span>isAdmin</span>
-            <div>no</div>
+            <dt>isAdmin</dt>
+            <dd>no</dd>
             </div>
-            </div>
+            </dl>
             </div>
             HTML,
             DetailView::widget()
@@ -354,20 +354,20 @@ final class BaseTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div>
+            <dl>
             <div>
-            <div>
-            <span>id</span>
-            <div>1</div>
+            <dt>id</dt>
+            <dd>1</dd>
             </div>
             <div>
-            <span>username</span>
-            <div>admin</div>
+            <dt>username</dt>
+            <dd>admin</dd>
             </div>
             <div>
-            <span>isAdmin</span>
-            <div>yes</div>
+            <dt>isAdmin</dt>
+            <dd>yes</dd>
             </div>
-            </div>
+            </dl>
             </div>
             HTML,
             DetailView::widget()
@@ -393,20 +393,20 @@ final class BaseTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div>
+            <dl>
             <div>
-            <div>
-            <span>id</span>
-            <div>1</div>
+            <dt>id</dt>
+            <dd>1</dd>
             </div>
             <div>
-            <span>username</span>
-            <div>tests 1</div>
+            <dt>username</dt>
+            <dd>tests 1</dd>
             </div>
             <div>
-            <span>total</span>
-            <div>0</div>
+            <dt>total</dt>
+            <dd>0</dd>
             </div>
-            </div>
+            </dl>
             </div>
             HTML,
             DetailView::widget()
@@ -423,20 +423,20 @@ final class BaseTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div>
+            <dl>
             <div>
-            <div>
-            <span>id</span>
-            <div>1</div>
+            <dt>id</dt>
+            <dd>1</dd>
             </div>
             <div>
-            <span>username</span>
-            <div>tests 1</div>
+            <dt>username</dt>
+            <dd>tests 1</dd>
             </div>
             <div>
-            <span>status</span>
-            <div>false</div>
+            <dt>status</dt>
+            <dd>false</dd>
             </div>
-            </div>
+            </dl>
             </div>
             HTML,
             DetailView::widget()
@@ -452,20 +452,20 @@ final class BaseTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div>
+            <dl>
             <div>
-            <div>
-            <span>id</span>
-            <div>1</div>
+            <dt>id</dt>
+            <dd>1</dd>
             </div>
             <div>
-            <span>username</span>
-            <div>tests 1</div>
+            <dt>username</dt>
+            <dd>tests 1</dd>
             </div>
             <div>
-            <span>status</span>
-            <div>true</div>
+            <dt>status</dt>
+            <dd>true</dd>
             </div>
-            </div>
+            </dl>
             </div>
             HTML,
             DetailView::widget()
@@ -496,20 +496,20 @@ final class BaseTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div>
+            <dl>
             <div>
-            <div>
-            <span>id</span>
-            <div>1</div>
+            <dt>id</dt>
+            <dd>1</dd>
             </div>
             <div>
-            <span>username</span>
-            <div>tests 1</div>
+            <dt>username</dt>
+            <dd>tests 1</dd>
             </div>
             <div>
-            <span>total</span>
-            <div>0</div>
+            <dt>total</dt>
+            <dd>0</dd>
             </div>
-            </div>
+            </dl>
             </div>
             HTML,
             DetailView::widget()
@@ -532,20 +532,20 @@ final class BaseTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div>
+            <dl>
             <div>
-            <div>
-            <span>id</span>
-            <div>1</div>
+            <dt>id</dt>
+            <dd>1</dd>
             </div>
             <div>
-            <span>username</span>
-            <div>tests 1</div>
+            <dt>username</dt>
+            <dd>tests 1</dd>
             </div>
             <div>
-            <span>status</span>
-            <div>false</div>
+            <dt>status</dt>
+            <dd>false</dd>
             </div>
-            </div>
+            </dl>
             </div>
             HTML,
             DetailView::widget()
@@ -567,20 +567,20 @@ final class BaseTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div>
+            <dl>
             <div>
-            <div>
-            <span>id</span>
-            <div>1</div>
+            <dt>id</dt>
+            <dd>1</dd>
             </div>
             <div>
-            <span>username</span>
-            <div>tests 1</div>
+            <dt>username</dt>
+            <dd>tests 1</dd>
             </div>
             <div>
-            <span>status</span>
-            <div>true</div>
+            <dt>status</dt>
+            <dd>true</dd>
             </div>
-            </div>
+            </dl>
             </div>
             HTML,
             DetailView::widget()

--- a/tests/DetailView/Bootstrap5Test.php
+++ b/tests/DetailView/Bootstrap5Test.php
@@ -30,21 +30,21 @@ final class Bootstrap5Test extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div class="container">
-            <div class="row flex-column justify-content-center align-items-center">
             <h2 class="text-center"><strong>Bootstrap 5</strong></h2>
+            <dl class="row flex-column justify-content-center align-items-center">
             <div class="col-xl-5">
-            <span class="fw-bold">Id</span>
-            <div class="alert alert-info">1</div>
-            </div>
-            <div class="col-xl-5">
-            <span class="fw-bold">login</span>
-            <div class="alert alert-info">test</div>
+            <dt class="fw-bold">Id</dt>
+            <dd class="alert alert-info">1</dd>
             </div>
             <div class="col-xl-5">
-            <span class="fw-bold">Created At</span>
-            <div class="alert alert-info">2020-01-01</div>
+            <dt class="fw-bold">login</dt>
+            <dd class="alert alert-info">test</dd>
             </div>
+            <div class="col-xl-5">
+            <dt class="fw-bold">Created At</dt>
+            <dd class="alert alert-info">2020-01-01</dd>
             </div>
+            </dl>
             </div>
             HTML,
             DetailView::widget()

--- a/tests/Field/DataFieldTest.php
+++ b/tests/Field/DataFieldTest.php
@@ -35,20 +35,20 @@ final class DataFieldTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div>
+            <dl>
             <div>
-            <div>
-            <span>id</span>
-            <div>1</div>
+            <dt>id</dt>
+            <dd>1</dd>
             </div>
             <div>
-            <span>username</span>
-            <div>admin</div>
+            <dt>username</dt>
+            <dd>admin</dd>
             </div>
             <div>
-            <span class="test-class">isAdmin</span>
-            <div>true</div>
+            <dt class="test-class">isAdmin</dt>
+            <dd>true</dd>
             </div>
-            </div>
+            </dl>
             </div>
             HTML,
             DetailView::widget()
@@ -73,20 +73,20 @@ final class DataFieldTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div>
+            <dl>
             <div>
-            <div>
-            <span>id</span>
-            <div>1</div>
+            <dt>id</dt>
+            <dd>1</dd>
             </div>
             <div>
-            <span>username</span>
-            <div>admin</div>
+            <dt>username</dt>
+            <dd>admin</dd>
             </div>
             <div>
             <p>isAdmin</p>
-            <div>true</div>
+            <dd>true</dd>
             </div>
-            </div>
+            </dl>
             </div>
             HTML,
             DetailView::widget()
@@ -111,20 +111,20 @@ final class DataFieldTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div>
+            <dl>
             <div>
-            <div>
-            <span>id</span>
-            <div>1</div>
+            <dt>id</dt>
+            <dd>1</dd>
             </div>
             <div>
-            <span>username</span>
-            <div>tests 1</div>
+            <dt>username</dt>
+            <dd>tests 1</dd>
             </div>
             <div>
-            <span>total</span>
-            <div class="text-success">10</div>
+            <dt>total</dt>
+            <dd class="text-success">10</dd>
             </div>
-            </div>
+            </dl>
             </div>
             HTML,
             DetailView::widget()
@@ -154,20 +154,20 @@ final class DataFieldTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div>
+            <dl>
             <div>
-            <div>
-            <span>id</span>
-            <div>1</div>
+            <dt>id</dt>
+            <dd>1</dd>
             </div>
             <div>
-            <span>username</span>
-            <div>tests 1</div>
+            <dt>username</dt>
+            <dd>tests 1</dd>
             </div>
             <div>
-            <span>status</span>
-            <div>yes</div>
+            <dt>status</dt>
+            <dd>yes</dd>
             </div>
-            </div>
+            </dl>
             </div>
             HTML,
             DetailView::widget()
@@ -200,20 +200,20 @@ final class DataFieldTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div>
+            <dl>
             <div>
-            <div>
-            <span>id</span>
-            <div>1</div>
+            <dt>id</dt>
+            <dd>1</dd>
             </div>
             <div>
-            <span>username</span>
-            <div>tests 1</div>
+            <dt>username</dt>
+            <dd>tests 1</dd>
             </div>
             <div>
-            <span>status</span>
-            <div>yes</div>
+            <dt>status</dt>
+            <dd>yes</dd>
             </div>
-            </div>
+            </dl>
             </div>
             HTML,
             DetailView::widget()
@@ -240,20 +240,20 @@ final class DataFieldTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div>
+            <dl>
             <div>
-            <div>
-            <span>id</span>
-            <div>1</div>
+            <dt>id</dt>
+            <dd>1</dd>
             </div>
             <div>
-            <span>username</span>
-            <div>guess</div>
+            <dt>username</dt>
+            <dd>guess</dd>
             </div>
             <div>
-            <span>isAdmin</span>
-            <div>1</div>
+            <dt>isAdmin</dt>
+            <dd>1</dd>
             </div>
-            </div>
+            </dl>
             </div>
             HTML,
             DetailView::widget()
@@ -279,20 +279,20 @@ final class DataFieldTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div>
+            <dl>
             <div>
-            <div>
-            <span>id</span>
-            <div>1</div>
+            <dt>id</dt>
+            <dd>1</dd>
             </div>
             <div>
-            <span>username</span>
-            <div>admin</div>
+            <dt>username</dt>
+            <dd>admin</dd>
             </div>
             <div>
-            <span>isAdmin</span>
+            <dt>isAdmin</dt>
             <p>true</p>
             </div>
-            </div>
+            </dl>
             </div>
             HTML,
             DetailView::widget()


### PR DESCRIPTION
Referring to `<dl>`: 

>  Common uses for this element are to implement a glossary or to display metadata (a list of key-value pairs).

as stated in https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dl.

I propose this change following the example in https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dl#wrapping_name-value_groups_in_div_elements

Proposed markup is...

```
<div>
    The header if provided
    <dl>
        <div>
            <dt>id</dt>
            <dd>1</dd>
        </div>
        <div>
            <dt>username</dt>
            <dd>tests 1</dd>
        </div>
        <div>
            <dt>status</dt>
            <dd>true</dd>
        </div>
    </dl>
</div>
```

...which I think is more semantic than the combination of `span` and `div` in the current template. 

A preview (with a bit of CSS) can be seen on https://codepen.io/glpzzz/pen/VwNYKwq 

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | Changes the output
