### PR TITLE
Update OffsetPagination.php

### DIFF
--- a/src/OffsetPagination.php
+++ b/src/OffsetPagination.php
@@ -30,31 +30,31 @@ final class OffsetPagination extends BasePagination
         return $new;
     }
 
-    public function labelPrevious(string|Stringable|null $labelPrevious): self
+    public function labelPrevious(string|Stringable|null $label): self
     {
         $new = clone $this;
-        $new->labelPrevious = $labelPrevious;
+        $new->labelPrevious = $label;
         return $new;
     }
 
-    public function labelNext(string|Stringable|null $labelNext): self
+    public function labelNext(string|Stringable|null $label): self
     {
         $new = clone $this;
-        $new->labelNext = $labelNext;
+        $new->labelNext = $label;
         return $new;
     }
 
-    public function labelFirst(string|Stringable|null $labelFirst): self
+    public function labelFirst(string|Stringable|null $label): self
     {
         $new = clone $this;
-        $new->labelFirst = $labelFirst;
+        $new->labelFirst = $label;
         return $new;
     }
 
-    public function labelLast(string|Stringable|null $labelLast): self
+    public function labelLast(string|Stringable|null $label): self
     {
         $new = clone $this;
-        $new->labelLast = $labelLast;
+        $new->labelLast = $label;
         return $new;
     }
 

--- a/src/OffsetPagination.php
+++ b/src/OffsetPagination.php
@@ -30,6 +30,33 @@ final class OffsetPagination extends BasePagination
         return $new;
     }
 
+    public function labelPrevious(string|Stringable|null $labelPrevious): self
+    {
+        $new=clone $this;
+        $new->labelPrevious=$labelPrevious;
+        return $new;
+    }
+    
+    public function labelNext(string|Stringable|null $labelNext): self
+    {
+        $new=clone $this;
+        $new->labelNext=$labelNext;
+        return $new;
+    }
+    
+    public function labelFirst(string|Stringable|null $labelFirst): self
+    {
+        $new=clone $this;
+        $new->labelFirst=$labelFirst;
+        return $new;
+    }
+    public function labelLast(string|Stringable|null $labelLast): self
+    {
+        $new=clone $this;
+        $new->labelLast=$labelLast;
+        return $new;
+    }
+    
     /**
      * Return a new instance with max nav link count.
      *

--- a/src/OffsetPagination.php
+++ b/src/OffsetPagination.php
@@ -32,31 +32,32 @@ final class OffsetPagination extends BasePagination
 
     public function labelPrevious(string|Stringable|null $labelPrevious): self
     {
-        $new=clone $this;
-        $new->labelPrevious=$labelPrevious;
+        $new = clone $this;
+        $new->labelPrevious = $labelPrevious;
         return $new;
     }
-    
+
     public function labelNext(string|Stringable|null $labelNext): self
     {
-        $new=clone $this;
-        $new->labelNext=$labelNext;
+        $new = clone $this;
+        $new->labelNext = $labelNext;
         return $new;
     }
-    
+
     public function labelFirst(string|Stringable|null $labelFirst): self
     {
-        $new=clone $this;
-        $new->labelFirst=$labelFirst;
+        $new = clone $this;
+        $new->labelFirst = $labelFirst;
         return $new;
     }
+
     public function labelLast(string|Stringable|null $labelLast): self
     {
-        $new=clone $this;
-        $new->labelLast=$labelLast;
+        $new = clone $this;
+        $new->labelLast = $labelLast;
         return $new;
     }
-    
+
     /**
      * Return a new instance with max nav link count.
      *


### PR DESCRIPTION
In OffsetPagination, no way of setting private member variables $labelPrevious, $labelNext, $labelFirst, $labelLast (Issue #177)

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ✔️
