### PR TITLE
Use `ul` and `li` tags for the default layout of the `ListView`.

### DIFF
--- a/src/ListView.php
+++ b/src/ListView.php
@@ -6,10 +6,10 @@ namespace Yiisoft\Yii\DataView;
 
 use Closure;
 use InvalidArgumentException;
-use Yiisoft\Html\Tag\Div;
+use Yiisoft\Html\Html;
+use Yiisoft\Html\Tag\Li;
 use Yiisoft\View\Exception\ViewNotFoundException;
 use Yiisoft\View\View;
-
 use function is_string;
 
 /**
@@ -21,6 +21,12 @@ final class ListView extends BaseListView
     private ?Closure $beforeItem = null;
 
     /**
+     * @psalm-var non-empty-string|null
+     */
+    private ?string $itemsWrapperTag = 'ul';
+    private array $itemsWrapperAttributes = [];
+
+    /**
      * @var callable|string|null
      */
     private $itemView = null;
@@ -29,6 +35,12 @@ final class ListView extends BaseListView
     private string $separator = "\n";
     private array $viewParams = [];
     private ?View $view = null;
+
+    public function __construct()
+    {
+        parent::__construct();
+        $this->containerTag('ul');
+    }
 
     /**
      * Return new instance with afterItem closure.
@@ -78,6 +90,24 @@ final class ListView extends BaseListView
         $new = clone $this;
         $new->beforeItem = $value;
 
+        return $new;
+    }
+
+    public function itemsWrapperTag(?string $tag): self
+    {
+        if ($tag === '') {
+            throw new InvalidArgumentException('Tag name cannot be empty.');
+        }
+
+        $new = clone $this;
+        $new->itemsWrapperTag = $tag;
+        return $new;
+    }
+
+    public function itemsWrapperAttributes(array $values): self
+    {
+        $new = clone $this;
+        $new->itemsWrapperAttributes = $values;
         return $new;
     }
 
@@ -182,10 +212,10 @@ final class ListView extends BaseListView
         }
 
         if ($this->itemView instanceof Closure) {
-            $content = (string) call_user_func($this->itemView, $data, $key, $index, $this);
+            $content = (string)call_user_func($this->itemView, $data, $key, $index, $this);
         }
 
-        return Div::tag()
+        return Li::tag()
             ->attributes($this->itemViewAttributes)
             ->content("\n" . $content)
             ->encode(false)
@@ -217,7 +247,13 @@ final class ListView extends BaseListView
             }
         }
 
-        return implode($this->separator, $rows);
+        $content = implode($this->separator, $rows);
+
+        return $this->itemsWrapperTag === null
+            ? $content
+            : Html::tag($this->itemsWrapperTag, "\n" . $content . "\n", $this->itemsWrapperAttributes)
+                ->encode(false)
+                ->render();
     }
 
     /**
@@ -238,7 +274,7 @@ final class ListView extends BaseListView
         $result = '';
 
         if (!empty($this->afterItem)) {
-            $result = (string) call_user_func($this->afterItem, $data, $key, $index, $this);
+            $result = (string)call_user_func($this->afterItem, $data, $key, $index, $this);
         }
 
         return $result;
@@ -262,7 +298,7 @@ final class ListView extends BaseListView
         $result = '';
 
         if (!empty($this->beforeItem)) {
-            $result = (string) call_user_func($this->beforeItem, $data, $key, $index, $this);
+            $result = (string)call_user_func($this->beforeItem, $data, $key, $index, $this);
         }
 
         return $result;

--- a/tests/ListView/BaseTest.php
+++ b/tests/ListView/BaseTest.php
@@ -27,16 +27,18 @@ final class BaseTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div>
+            <ul>
             <span class="testMe">
-            <div>
+            <li>
             <div>Id: 1</div><div>Name: John</div><div>Age: 20</div>
-            </div>
+            </li>
             </span>
             <span class="testMe">
-            <div>
+            <li>
             <div>Id: 2</div><div>Name: Mary</div><div>Age: 21</div>
-            </div>
+            </li>
             </span>
+            </ul>
             <div>Page <b>1</b> of <b>1</b></div>
             </div>
             HTML,
@@ -54,12 +56,14 @@ final class BaseTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div>
-            <div class="testMe">
+            <ul>
+            <li class="testMe">
             <div>Id: 1</div><div>Name: John</div><div>Age: 20</div>
-            </div>
-            <div class="testMe">
+            </li>
+            <li class="testMe">
             <div>Id: 2</div><div>Name: Mary</div><div>Age: 21</div>
-            </div>
+            </li>
+            </ul>
             <div>Page <b>1</b> of <b>1</b></div>
             </div>
             HTML,
@@ -76,12 +80,14 @@ final class BaseTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div>
-            <div>
+            <ul>
+            <li>
             <div>Id: 1</div><div>Name: John</div><div>Age: 20</div>
-            </div>
-            <div>
+            </li>
+            <li>
             <div>Id: 2</div><div>Name: Mary</div><div>Age: 21</div>
-            </div>
+            </li>
+            </ul>
             <div>Page <b>1</b> of <b>1</b></div>
             </div>
             HTML,
@@ -103,12 +109,14 @@ final class BaseTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div>
-            <div>
+            <ul>
+            <li>
             <div>1</div><div>John</div>
-            </div>
-            <div>
+            </li>
+            <li>
             <div>2</div><div>Mary</div>
-            </div>
+            </li>
+            </ul>
             <div>Page <b>1</b> of <b>1</b></div>
             </div>
             HTML,
@@ -132,12 +140,14 @@ final class BaseTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div>
-            <div>
+            <ul>
+            <li>
             <div>Id: 1</div><div>Name: John</div><div>Age: 20</div>
-            </div>
-            <div>
+            </li>
+            <li>
             <div>Id: 2</div><div>Name: Mary</div><div>Age: 21</div>
-            </div>
+            </li>
+            </ul>
             <div>Page <b>1</b> of <b>1</b></div>
             </div>
             HTML,
@@ -160,12 +170,14 @@ final class BaseTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div>
-            <div>
+            <ul>
+            <li>
             <div class=text-success>1</div>
-            </div>
-            <div>
+            </li>
+            <li>
             <div class=text-success>2</div>
-            </div>
+            </li>
+            </ul>
             <div>Page <b>1</b> of <b>1</b></div>
             </div>
             HTML,
@@ -183,9 +195,11 @@ final class BaseTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div>
-            <div>
+            <ul>
+            <li>
             <div class=text-success>1</div>
-            </div>
+            </li>
+            </ul>
             <div>Page <b>1</b> of <b>2</b></div>
             <nav>
             <ul class="pagination">
@@ -222,9 +236,11 @@ final class BaseTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div>
-            <div>
+            <ul>
+            <li>
             <div class=text-success>1</div>
-            </div>
+            </li>
+            </ul>
 
             <nav>
             <ul class="pagination">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ✔️

As per commented on #14, `ul` and `li` tags are used for the default layout of the ListView.
