### PR TITLE
Fix #211: ListView::itemViewAttributes() accepts Closure as parameter.

### DIFF
--- a/src/ListView.php
+++ b/src/ListView.php
@@ -193,8 +193,14 @@ final class ListView extends BaseListView
         }
 
         $itemViewAttributes = is_callable($this->itemViewAttributes)
-            ? (array) call_user_func($this->itemViewAttributes, $data, $key, $index, $this)
+            ? (array)call_user_func($this->itemViewAttributes, $data, $key, $index, $this)
             : $this->itemViewAttributes;
+
+        foreach ($itemViewAttributes as $i => $attribute) {
+            if (is_callable($attribute)) {
+                $itemViewAttributes[$i] = $attribute($data, $key, $index, $this);
+            }
+        }
 
         return Div::tag()
             ->attributes($itemViewAttributes)

--- a/src/ListView.php
+++ b/src/ListView.php
@@ -117,6 +117,13 @@ final class ListView extends BaseListView
      * function ($data, $key, $index, $widget)
      * ```
      *
+     * Also, each attribute value can be a closure too, with the same signature as in:
+     *
+     * ```php
+     * [
+     *     'class' => static fn($data, $key, $index, $widget) => "custom-class-{$data['id']}",
+     * ]
+     * ```
      * @param array|Closure $values Attribute values indexed by attribute names.
      * @return ListView
      */

--- a/src/ListView.php
+++ b/src/ListView.php
@@ -174,7 +174,7 @@ final class ListView extends BaseListView
      * function ($data, $key, $index, $widget)
      * ```
      *
-     * Also, each attribute value can be a closure too, with the same signature as in:
+     * Also, each attribute value can be a function too, with the same signature as in:
      *
      * ```php
      * [

--- a/src/ListView.php
+++ b/src/ListView.php
@@ -167,13 +167,14 @@ final class ListView extends BaseListView
 
     /**
      * Return new instance with the HTML attributes for the container of item view.
+     *
+     * @param array|Closure $values Attribute values indexed by attribute names.
      * If this property is specified as a function, it must return an array of attributes and have the following
      * signature:
      *
      * ```php
      * function ($data, $key, $index, $widget)
      * ```
-     *
      * Also, each attribute value can be a function too, with the same signature as in:
      *
      * ```php
@@ -181,7 +182,6 @@ final class ListView extends BaseListView
      *     'class' => static fn($data, $key, $index, $widget) => "custom-class-{$data['id']}",
      * ]
      * ```
-     * @param array|Closure $values Attribute values indexed by attribute names.
      * @return ListView
      */
     public function itemViewAttributes(array|Closure $values): self

--- a/src/ListView.php
+++ b/src/ListView.php
@@ -167,7 +167,7 @@ final class ListView extends BaseListView
 
     /**
      * Return new instance with the HTML attributes for the container of item view.
-     * If this property is specified as a callback, it must return an array of attributes and have the following
+     * If this property is specified as a function, it must return an array of attributes and have the following
      * signature:
      *
      * ```php

--- a/src/ListView.php
+++ b/src/ListView.php
@@ -25,7 +25,7 @@ final class ListView extends BaseListView
      */
     private $itemView = null;
 
-    private array $itemViewAttributes = [];
+    private array|Closure $itemViewAttributes = [];
     private string $separator = "\n";
     private array $viewParams = [];
     private ?View $view = null;
@@ -109,11 +109,18 @@ final class ListView extends BaseListView
     }
 
     /**
-     * return new instance with the HTML attributes for the container of item view.
+     * Return new instance with the HTML attributes for the container of item view.
+     * If this property is specified as a callback, it must return an array of attributes and have the following
+     * signature:
      *
-     * @param array $values Attribute values indexed by attribute names.
+     * ```php
+     * function ($data, $key, $index, $widget)
+     * ```
+     *
+     * @param array|Closure $values Attribute values indexed by attribute names.
+     * @return ListView
      */
-    public function itemViewAttributes(array $values): self
+    public function itemViewAttributes(array|Closure $values): self
     {
         $new = clone $this;
         $new->itemViewAttributes = $values;
@@ -185,8 +192,12 @@ final class ListView extends BaseListView
             $content = (string) call_user_func($this->itemView, $data, $key, $index, $this);
         }
 
+        $itemViewAttributes = is_callable($this->itemViewAttributes)
+            ? (array) call_user_func($this->itemViewAttributes, $data, $key, $index, $this)
+            : $this->itemViewAttributes;
+
         return Div::tag()
-            ->attributes($this->itemViewAttributes)
+            ->attributes($itemViewAttributes)
             ->content("\n" . $content)
             ->encode(false)
             ->render();

--- a/tests/ListView/BaseTest.php
+++ b/tests/ListView/BaseTest.php
@@ -251,4 +251,31 @@ final class BaseTest extends TestCase
                 ->render(),
         );
     }
+
+    public function testClosureForItemViewAttributes(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <div>
+            <div data-item-id="1" data-item-key="0" data-item-index="0">
+            <div>Id: 1</div><div>Name: John</div><div>Age: 20</div>
+            </div>
+            <div data-item-id="2" data-item-key="1" data-item-index="1">
+            <div>Id: 2</div><div>Name: Mary</div><div>Age: 21</div>
+            </div>
+            <div>Page <b>1</b> of <b>1</b></div>
+            </div>
+            HTML,
+            ListView::widget()
+                ->itemView(dirname(__DIR__) . '/Support/view/_listview.php')
+                ->itemViewAttributes(static fn (array $data, $key, $index, $widget) => [
+                    'data-item-id' => $data['id'],
+                    'data-item-key' => $key,
+                    'data-item-index' => $index,
+                ])
+                ->dataReader($this->createOffsetPaginator($this->data, 10))
+                ->separator(PHP_EOL)
+                ->render(),
+        );
+    }
 }

--- a/tests/ListView/BaseTest.php
+++ b/tests/ListView/BaseTest.php
@@ -413,12 +413,14 @@ final class BaseTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div>
-            <div data-item-id="1" data-item-key="0" data-item-index="0">
+            <ul>
+            <li data-item-id="1" data-item-key="0" data-item-index="0">
             <div>Id: 1</div><div>Name: John</div><div>Age: 20</div>
-            </div>
-            <div data-item-id="2" data-item-key="1" data-item-index="1">
+            </li>
+            <li data-item-id="2" data-item-key="1" data-item-index="1">
             <div>Id: 2</div><div>Name: Mary</div><div>Age: 21</div>
-            </div>
+            </li>
+            </ul>
             <div>Page <b>1</b> of <b>1</b></div>
             </div>
             HTML,
@@ -440,12 +442,14 @@ final class BaseTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div>
-            <div class="id-1-key-0-index-0">
+            <ul>
+            <li class="id-1-key-0-index-0">
             <div>Id: 1</div><div>Name: John</div><div>Age: 20</div>
-            </div>
-            <div class="id-2-key-1-index-1">
+            </li>
+            <li class="id-2-key-1-index-1">
             <div>Id: 2</div><div>Name: Mary</div><div>Age: 21</div>
-            </div>
+            </li>
+            </ul>
             <div>Page <b>1</b> of <b>1</b></div>
             </div>
             HTML,
@@ -465,12 +469,14 @@ final class BaseTest extends TestCase
         Assert::equalsWithoutLE(
             <<<HTML
             <div>
-            <div class="id-1-key-0-index-0">
+            <ul>
+            <li class="id-1-key-0-index-0">
             <div>Id: 1</div><div>Name: John</div><div>Age: 20</div>
-            </div>
-            <div class="id-2-key-1-index-1">
+            </li>
+            <li class="id-2-key-1-index-1">
             <div>Id: 2</div><div>Name: Mary</div><div>Age: 21</div>
-            </div>
+            </li>
+            </ul>
             <div>Page <b>1</b> of <b>1</b></div>
             </div>
             HTML,

--- a/tests/ListView/BaseTest.php
+++ b/tests/ListView/BaseTest.php
@@ -278,4 +278,54 @@ final class BaseTest extends TestCase
                 ->render(),
         );
     }
+
+    public function testItemViewAttributesWithClosure(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <div>
+            <div class="id-1-key-0-index-0">
+            <div>Id: 1</div><div>Name: John</div><div>Age: 20</div>
+            </div>
+            <div class="id-2-key-1-index-1">
+            <div>Id: 2</div><div>Name: Mary</div><div>Age: 21</div>
+            </div>
+            <div>Page <b>1</b> of <b>1</b></div>
+            </div>
+            HTML,
+            ListView::widget()
+                ->itemView(dirname(__DIR__) . '/Support/view/_listview.php')
+                ->itemViewAttributes([
+                    'class' => static fn(array $data, $key, $index) => "id-{$data['id']}-key-{$key}-index-{$index}",
+                ])
+                ->dataReader($this->createOffsetPaginator($this->data, 10))
+                ->separator(PHP_EOL)
+                ->render(),
+        );
+    }
+
+    public function testClosureForItemViewAttributesWithClosure(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <div>
+            <div class="id-1-key-0-index-0">
+            <div>Id: 1</div><div>Name: John</div><div>Age: 20</div>
+            </div>
+            <div class="id-2-key-1-index-1">
+            <div>Id: 2</div><div>Name: Mary</div><div>Age: 21</div>
+            </div>
+            <div>Page <b>1</b> of <b>1</b></div>
+            </div>
+            HTML,
+            ListView::widget()
+                ->itemView(dirname(__DIR__) . '/Support/view/_listview.php')
+                ->itemViewAttributes(static fn (array $data, $key, $index) => [
+                    'class' => static fn(array $data, $key, $index) => "id-{$data['id']}-key-{$key}-index-{$index}",
+                ])
+                ->dataReader($this->createOffsetPaginator($this->data, 10))
+                ->separator(PHP_EOL)
+                ->render(),
+        );
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌

Refs #211 