### PR TITLE
Fix #213: use ListItemContext for `ListView::renderItem` related operations.

### DIFF
--- a/src/ListItemContext.php
+++ b/src/ListItemContext.php
@@ -6,7 +6,12 @@ namespace Yiisoft\Yii\DataView;
 
 final class ListItemContext
 {
-
+    /**
+     * @param array|object $data The current data being rendered.
+     * @param int|string $key The key value associated with the current data.
+     * @param int $index The zero-based index of the data in the array.
+     * @param ListView $widget The list view object.
+     */
     public function __construct(
         public readonly array|object $data,
         public readonly int|string $key,

--- a/src/ListItemContext.php
+++ b/src/ListItemContext.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Yiisoft\Yii\DataView;
 
 final class ListItemContext
@@ -10,7 +12,6 @@ final class ListItemContext
         public readonly int|string $key,
         public readonly int $index,
         public readonly ListView $widget,
-    )
-    {
+    ) {
     }
 }

--- a/src/ListItemContext.php
+++ b/src/ListItemContext.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Yiisoft\Yii\DataView;
+
+final class ListItemContext
+{
+
+    public function __construct(
+        public readonly array|object $data,
+        public readonly int|string $key,
+        public readonly int $index,
+        public readonly ListView $widget,
+    )
+    {
+    }
+}

--- a/src/ListView.php
+++ b/src/ListView.php
@@ -69,13 +69,8 @@ final class ListView extends BaseListView
      * It should have the following signature:
      *
      * ```php
-     * function ($data, $key, $index, $widget)
+     * function (ListItemContext $context)
      * ```
-     *
-     * - `$data`: The current data being rendered.
-     * - `$key`: The key value associated with the current data.
-     * - `$index`: The zero-based index of the data in the array.
-     * - `$widget`: The list view object.
      *
      * The return result of the function will be rendered directly.
      *
@@ -325,7 +320,7 @@ final class ListView extends BaseListView
         $result = '';
 
         if (!empty($this->afterItem)) {
-            $result = (string)call_user_func($this->afterItem, $context->data, $context->key, $context->index, $context->widget);
+            $result = (string)call_user_func($this->afterItem, $context);
         }
 
         return $result;
@@ -347,7 +342,7 @@ final class ListView extends BaseListView
         $result = '';
 
         if (!empty($this->beforeItem)) {
-            $result = (string)call_user_func($this->beforeItem, $context->data, $context->key, $context->index, $context->widget);
+            $result = (string)call_user_func($this->beforeItem, $context);
         }
 
         return $result;

--- a/src/ListView.php
+++ b/src/ListView.php
@@ -246,11 +246,11 @@ final class ListView extends BaseListView
         }
 
         if ($this->itemView instanceof Closure) {
-            $content = (string)call_user_func($this->itemView, $context);
+            $content = (string)($this->itemView)($context);
         }
 
         $itemViewAttributes = is_callable($this->itemViewAttributes)
-            ? (array)call_user_func($this->itemViewAttributes, $context)
+            ? (array)($this->itemViewAttributes)($context)
             : $this->itemViewAttributes;
 
         foreach ($itemViewAttributes as $i => $attribute) {
@@ -320,7 +320,7 @@ final class ListView extends BaseListView
         $result = '';
 
         if (!empty($this->afterItem)) {
-            $result = (string)call_user_func($this->afterItem, $context);
+            $result = (string)($this->afterItem)($context);
         }
 
         return $result;
@@ -342,7 +342,7 @@ final class ListView extends BaseListView
         $result = '';
 
         if (!empty($this->beforeItem)) {
-            $result = (string)call_user_func($this->beforeItem, $context);
+            $result = (string)($this->beforeItem)($context);
         }
 
         return $result;

--- a/src/ListView.php
+++ b/src/ListView.php
@@ -173,13 +173,13 @@ final class ListView extends BaseListView
      * signature:
      *
      * ```php
-     * function ($data, $key, $index, $widget)
+     * function (ListItemContext $context)
      * ```
      * Also, each attribute value can be a function too, with the same signature as in:
      *
      * ```php
      * [
-     *     'class' => static fn($data, $key, $index, $widget) => "custom-class-{$data['id']}",
+     *     'class' => static fn(ListItemContext $context) => "custom-class-{$context->data['id']}",
      * ]
      * ```
      * @return ListView
@@ -223,13 +223,11 @@ final class ListView extends BaseListView
     /**
      * Renders a single data model.
      *
-     * @param array|object $data The data to be rendered.
-     * @param mixed $key The key value associated with the data.
-     * @param int $index The zero-based index of the data array.
+     * @param ListItemContext $context
      *
      * @throws ViewNotFoundException If the item view file doesn't exist.
      */
-    protected function renderItem(array|object $data, mixed $key, int $index): string
+    protected function renderItem(ListItemContext $context): string
     {
         $content = '';
 
@@ -242,9 +240,9 @@ final class ListView extends BaseListView
                 $this->itemView,
                 array_merge(
                     [
-                        'data' => $data,
-                        'index' => $index,
-                        'key' => $key,
+                        'data' => $context->data,
+                        'index' => $context->index,
+                        'key' => $context->key,
                         'widget' => $this,
                     ],
                     $this->viewParams
@@ -253,16 +251,16 @@ final class ListView extends BaseListView
         }
 
         if ($this->itemView instanceof Closure) {
-            $content = (string)call_user_func($this->itemView, $data, $key, $index, $this);
+            $content = (string)call_user_func($this->itemView, $context);
         }
 
         $itemViewAttributes = is_callable($this->itemViewAttributes)
-            ? (array)call_user_func($this->itemViewAttributes, $data, $key, $index, $this)
+            ? (array)call_user_func($this->itemViewAttributes, $context)
             : $this->itemViewAttributes;
 
         foreach ($itemViewAttributes as $i => $attribute) {
             if (is_callable($attribute)) {
-                $itemViewAttributes[$i] = $attribute($data, $key, $index, $this);
+                $itemViewAttributes[$i] = $attribute($context);
             }
         }
 
@@ -289,13 +287,15 @@ final class ListView extends BaseListView
         foreach (array_values($items) as $index => $value) {
             $key = $keys[$index];
 
-            if ('' !== ($before = $this->renderBeforeItem($value, $key, $index))) {
+            $itemContext = new ListItemContext($value, $key, $index, $this);
+
+            if ('' !== ($before = $this->renderBeforeItem($itemContext))) {
                 $rows[] = $before;
             }
 
-            $rows[] = $this->renderItem($value, $key, $index);
+            $rows[] = $this->renderItem($itemContext);
 
-            if ('' !== ($after = $this->renderAfterItem($value, $key, $index))) {
+            if ('' !== ($after = $this->renderAfterItem($itemContext))) {
                 $rows[] = $after;
             }
         }
@@ -314,20 +314,18 @@ final class ListView extends BaseListView
      *
      * If {@see afterItem} is not a closure, `null` will be returned.
      *
-     * @param array|object $data The data to be rendered.
-     * @param mixed $key The key value associated with the data.
-     * @param int $index The zero-based index of the data.
+     * @param ListItemContext $context context of the item to be rendered.
      *
      * @return string call result when {@see afterItem} is not a closure.
      *
      * {@see afterItem}
      */
-    private function renderAfterItem(array|object $data, mixed $key, int $index): string
+    private function renderAfterItem(ListItemContext $context): string
     {
         $result = '';
 
         if (!empty($this->afterItem)) {
-            $result = (string)call_user_func($this->afterItem, $data, $key, $index, $this);
+            $result = (string)call_user_func($this->afterItem, $context->data, $context->key, $context->index, $context->widget);
         }
 
         return $result;
@@ -338,20 +336,18 @@ final class ListView extends BaseListView
      *
      * If {@see beforeItem} is not a closure, `null` will be returned.
      *
-     * @param array|object $data The data to be rendered.
-     * @param mixed $key The key value associated with the data.
-     * @param int $index The zero-based index of the data.
+     * @param ListItemContext $context context of the item to be rendered.
      *
      * @return string call result or `null` when {@see beforeItem} is not a closure.
      *
      * {@see beforeItem}
      */
-    private function renderBeforeItem(array|object $data, mixed $key, int $index): string
+    private function renderBeforeItem(ListItemContext $context): string
     {
         $result = '';
 
         if (!empty($this->beforeItem)) {
-            $result = (string)call_user_func($this->beforeItem, $data, $key, $index, $this);
+            $result = (string)call_user_func($this->beforeItem, $context->data, $context->key, $context->index, $context->widget);
         }
 
         return $result;

--- a/tests/ListView/BaseTest.php
+++ b/tests/ListView/BaseTest.php
@@ -81,7 +81,6 @@ final class BaseTest extends TestCase
         );
     }
 
-
     public function testItemViewAttributes(): void
     {
         Assert::equalsWithoutLE(

--- a/tests/ListView/BaseTest.php
+++ b/tests/ListView/BaseTest.php
@@ -9,6 +9,7 @@ use Yiisoft\Definitions\Exception\CircularReferenceException;
 use Yiisoft\Definitions\Exception\InvalidConfigException;
 use Yiisoft\Definitions\Exception\NotInstantiableException;
 use Yiisoft\Factory\NotFoundException;
+use Yiisoft\Yii\DataView\ListItemContext;
 use Yiisoft\Yii\DataView\ListView;
 use Yiisoft\Yii\DataView\Tests\Support\Assert;
 use Yiisoft\Yii\DataView\Tests\Support\TestTrait;
@@ -122,7 +123,7 @@ final class BaseTest extends TestCase
             HTML,
             ListView::widget()
                 ->itemView(
-                    fn (array $data) => '<div>' . $data['id'] . '</div><div>' . $data['name'] . '</div>' . PHP_EOL
+                    fn (ListItemContext $context) => '<div>' . $context->data['id'] . '</div><div>' . $context->data['name'] . '</div>' . PHP_EOL
                 )
                 ->dataReader($this->createOffsetPaginator($this->data, 10))
                 ->render(),
@@ -426,10 +427,10 @@ final class BaseTest extends TestCase
             HTML,
             ListView::widget()
                 ->itemView(dirname(__DIR__) . '/Support/view/_listview.php')
-                ->itemViewAttributes(static fn (array $data, $key, $index, $widget) => [
-                    'data-item-id' => $data['id'],
-                    'data-item-key' => $key,
-                    'data-item-index' => $index,
+                ->itemViewAttributes(static fn (ListItemContext $context) => [
+                    'data-item-id' => $context->data['id'],
+                    'data-item-key' => $context->key,
+                    'data-item-index' => $context->index,
                 ])
                 ->dataReader($this->createOffsetPaginator($this->data, 10))
                 ->separator(PHP_EOL)
@@ -456,7 +457,7 @@ final class BaseTest extends TestCase
             ListView::widget()
                 ->itemView(dirname(__DIR__) . '/Support/view/_listview.php')
                 ->itemViewAttributes([
-                    'class' => static fn(array $data, $key, $index) => "id-{$data['id']}-key-{$key}-index-{$index}",
+                    'class' => static fn(ListItemContext $context) => "id-{$context->data['id']}-key-{$context->key}-index-{$context->index}",
                 ])
                 ->dataReader($this->createOffsetPaginator($this->data, 10))
                 ->separator(PHP_EOL)
@@ -482,8 +483,8 @@ final class BaseTest extends TestCase
             HTML,
             ListView::widget()
                 ->itemView(dirname(__DIR__) . '/Support/view/_listview.php')
-                ->itemViewAttributes(static fn (array $data, $key, $index) => [
-                    'class' => static fn(array $data, $key, $index) => "id-{$data['id']}-key-{$key}-index-{$index}",
+                ->itemViewAttributes(static fn (ListItemContext $context) => [
+                    'class' => static fn(ListItemContext $context) => "id-{$context->data['id']}-key-{$context->key}-index-{$context->index}",
                 ])
                 ->dataReader($this->createOffsetPaginator($this->data, 10))
                 ->separator(PHP_EOL)

--- a/tests/ListView/BaseTest.php
+++ b/tests/ListView/BaseTest.php
@@ -52,6 +52,36 @@ final class BaseTest extends TestCase
         );
     }
 
+    public function testAfterItemBeforeItemWithClosure(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <div>
+            <ul>
+            <span class="testMe" data-item-id="1">
+            <li>
+            <div>Id: 1</div><div>Name: John</div><div>Age: 20</div>
+            </li>
+            <span data-item-id="1">just for test</span></span>
+            <span class="testMe" data-item-id="2">
+            <li>
+            <div>Id: 2</div><div>Name: Mary</div><div>Age: 21</div>
+            </li>
+            <span data-item-id="2">just for test</span></span>
+            </ul>
+            <div>Page <b>1</b> of <b>1</b></div>
+            </div>
+            HTML,
+            ListView::widget()
+                ->afterItem(static fn (ListItemContext $context) => '<span data-item-id="' . $context->data['id'] . '">just for test</span></span>')
+                ->beforeItem(static fn (ListItemContext $context) => '<span class="testMe" data-item-id="' . $context->data['id'] . '">')
+                ->itemView(dirname(__DIR__) . '/Support/view/_listview.php')
+                ->dataReader($this->createOffsetPaginator($this->data, 10))
+                ->render(),
+        );
+    }
+
+
     public function testItemViewAttributes(): void
     {
         Assert::equalsWithoutLE(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌

Refs #213 
