### PR TITLE
Fix #235. Rename attributes to properties. Rename methods

### DIFF
--- a/src/DetailView.php
+++ b/src/DetailView.php
@@ -35,8 +35,8 @@ use Yiisoft\Yii\DataView\Field\DataField;
  */
 final class DetailView extends Widget
 {
-    private array $attributes = [];
-    private array $containerAttributes = [];
+    private array $properties = [];
+    private array $containerProperties = [];
     private array|object $data = [];
     private array $dataAttributes = [];
     private array $fields = [];
@@ -46,7 +46,7 @@ final class DetailView extends Widget
     private string $labelTag = 'dt';
     private string $labelTemplate = '<{labelTag}{labelAttributes}>{label}</{labelTag}>';
     private string $template = "<div{attributes}>\n{header}\n<dl{containerAttributes}>\n{items}\n</dl>\n</div>";
-    private array|Closure $valueAttributes = [];
+    private array|Closure $valueProperties = [];
     private string $valueFalse = 'false';
     private string $valueTag = 'dd';
     private string $valueTemplate = '<{valueTag}{valueAttributes}>{value}</{valueTag}>';
@@ -57,10 +57,10 @@ final class DetailView extends Widget
      *
      * @param array $values Attribute values indexed by attribute names.
      */
-    public function attributes(array $values): self
+    public function properties(array $values): self
     {
         $new = clone $this;
-        $new->attributes = $values;
+        $new->properties = $values;
 
         return $new;
     }
@@ -70,10 +70,10 @@ final class DetailView extends Widget
      *
      * @param array $values Attribute values indexed by attribute names.
      */
-    public function containerAttributes(array $values): self
+    public function containerProperties(array $values): self
     {
         $new = clone $this;
-        $new->containerAttributes = $values;
+        $new->containerProperties = $values;
 
         return $new;
     }
@@ -208,10 +208,10 @@ final class DetailView extends Widget
      *
      * @param array $values Attribute values indexed by attribute names.
      */
-    public function valueAttributes(array $values): self
+    public function valueProperties(array $values): self
     {
         $new = clone $this;
-        $new->valueAttributes = $values;
+        $new->valueProperties = $values;
 
         return $new;
     }
@@ -281,8 +281,8 @@ final class DetailView extends Widget
             strtr(
                 $this->template,
                 [
-                    '{attributes}' => Html::renderTagAttributes($this->attributes),
-                    '{containerAttributes}' => Html::renderTagAttributes($this->containerAttributes),
+                    '{attributes}' => Html::renderTagAttributes($this->properties),
+                    '{containerAttributes}' => Html::renderTagAttributes($this->containerProperties),
                     '{dataAttributes}' => Html::renderTagAttributes($this->dataAttributes),
                     '{header}' => $this->header,
                     '{items}' => $this->renderItems(),
@@ -323,7 +323,7 @@ final class DetailView extends Widget
             $labelTag = $field->getLabelTag() === '' ? $this->labelTag : $field->getLabelTag();
             $valueTag = $field->getValueTag() === '' ? $this->valueTag : $field->getValueTag();
             $valueAttributes = $field->getValueAttributes() === []
-                ? $this->valueAttributes : $field->getValueAttributes();
+                ? $this->valueProperties : $field->getValueAttributes();
 
             $normalized[] = [
                 'label' => Html::encode($field->getLabel()),

--- a/tests/DetailView/BaseTest.php
+++ b/tests/DetailView/BaseTest.php
@@ -47,7 +47,7 @@ final class BaseTest extends TestCase
             </div>
             HTML,
             DetailView::widget()
-                ->attributes(['class' => 'test-class'])
+                ->properties(['class' => 'test-class'])
                 ->fields(
                     DataField::create()->attribute('id'),
                     DataField::create()->attribute('username'),
@@ -91,7 +91,7 @@ final class BaseTest extends TestCase
                     DataField::create()->attribute('username'),
                     DataField::create()->attribute('total'),
                 )
-                ->containerAttributes(['class' => 'test-class'])
+                ->containerProperties(['class' => 'test-class'])
                 ->data(['id' => 1, 'username' => 'tests 1', 'total' => '10'])
                 ->render(),
         );
@@ -299,7 +299,7 @@ final class BaseTest extends TestCase
                     DataField::create()->attribute('total'),
                 )
                 ->data(['id' => 1, 'username' => 'tests 1', 'total' => '10'])
-                ->valueAttributes(['class' => 'test-value'])
+                ->valueProperties(['class' => 'test-value'])
                 ->render(),
         );
     }

--- a/tests/DetailView/Bootstrap5Test.php
+++ b/tests/DetailView/Bootstrap5Test.php
@@ -48,13 +48,13 @@ final class Bootstrap5Test extends TestCase
             </div>
             HTML,
             DetailView::widget()
-                ->attributes(['class' => 'container'])
+                ->properties(['class' => 'container'])
                 ->fields(
                     DataField::create()->attribute('id')->label('Id'),
                     DataField::create()->attribute('login'),
                     DataField::create()->attribute('created_at')->label('Created At'),
                 )
-                ->containerAttributes(['class' => 'row flex-column justify-content-center align-items-center'])
+                ->containerProperties(['class' => 'row flex-column justify-content-center align-items-center'])
                 ->data(
                     [
                         'id' => 1,
@@ -67,7 +67,7 @@ final class Bootstrap5Test extends TestCase
                     H2::tag()->addClass('text-center')->content('<strong>Bootstrap 5</strong>')->encode(false)->render()
                 )
                 ->labelAttributes(['class' => 'fw-bold'])
-                ->valueAttributes(['class' => 'alert alert-info'])
+                ->valueProperties(['class' => 'alert alert-info'])
                 ->render(),
         );
     }
@@ -99,7 +99,7 @@ final class Bootstrap5Test extends TestCase
             </table>
             HTML,
             DetailView::widget()
-                ->attributes(['class' => 'table table-success table-striped'])
+                ->properties(['class' => 'table table-success table-striped'])
                 ->fields(
                     DataField::create()->attribute('id')->label('Id'),
                     DataField::create()->attribute('login'),

--- a/tests/DetailView/ImmutableTest.php
+++ b/tests/DetailView/ImmutableTest.php
@@ -26,9 +26,9 @@ final class ImmutableTest extends TestCase
     public function testImmutable(): void
     {
         $detailView = DetailView::widget();
-        $this->assertNotSame($detailView, $detailView->attributes([]));
+        $this->assertNotSame($detailView, $detailView->properties([]));
         $this->assertNotSame($detailView, $detailView->fields(DataField::create()));
-        $this->assertNotSame($detailView, $detailView->containerAttributes([]));
+        $this->assertNotSame($detailView, $detailView->containerProperties([]));
         $this->assertNotSame($detailView, $detailView->data([]));
         $this->assertNotSame($detailView, $detailView->dataAttributes([]));
         $this->assertNotSame($detailView, $detailView->header(''));
@@ -37,7 +37,7 @@ final class ImmutableTest extends TestCase
         $this->assertNotSame($detailView, $detailView->labelTag(''));
         $this->assertNotSame($detailView, $detailView->labelTemplate(''));
         $this->assertNotSame($detailView, $detailView->template(''));
-        $this->assertNotSame($detailView, $detailView->valueAttributes([]));
+        $this->assertNotSame($detailView, $detailView->valueProperties([]));
         $this->assertNotSame($detailView, $detailView->valueFalse(''));
         $this->assertNotSame($detailView, $detailView->valueTag(''));
         $this->assertNotSame($detailView, $detailView->valueTemplate(''));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
