### PR TITLE
Cleanup

### DIFF
--- a/src/BaseListView.php
+++ b/src/BaseListView.php
@@ -143,7 +143,7 @@ abstract class BaseListView extends Widget
     protected UrlParameterProviderInterface|null $urlParameterProvider = null;
 
     private bool $ignoreMissingPage = true;
-    protected bool $enableMultiSort = false;
+    protected bool $multiSort = false;
 
     /**
      * @psalm-var PageNotFoundExceptionCallback|null
@@ -223,10 +223,10 @@ abstract class BaseListView extends Widget
         return $new;
     }
 
-    final public function enableMultiSort(bool $enable = true): static
+    final public function multiSort(bool $enable = true): static
     {
         $new = clone $this;
-        $new->enableMultiSort = $enable;
+        $new->multiSort = $enable;
         return $new;
     }
 
@@ -772,7 +772,7 @@ abstract class BaseListView extends Widget
             $sortObject = $dataReader->getSort();
             if ($sortObject !== null) {
                 $order = OrderHelper::stringToArray($sort);
-                if (!$this->enableMultiSort) {
+                if (!$this->multiSort) {
                     $order = array_slice($order, 0, 1, true);
                 }
                 $dataReader = $dataReader->withSort(

--- a/src/Column/Base/HeaderContext.php
+++ b/src/Column/Base/HeaderContext.php
@@ -46,7 +46,7 @@ final class HeaderContext
      * @param string|null $sortableLinkDescClass CSS class for descending sort links.
      * @param PageToken|null $pageToken Current page token for pagination.
      * @param int|null $pageSize Number of items per page.
-     * @param bool $enableMultiSort Whether multiple column sorting is enabled.
+     * @param bool $multiSort Whether multiple column sorting is enabled.
      * @param UrlConfig $urlConfig URL configuration settings.
      * @param UrlCreator|null $urlCreator Callback for creating sort URLs.
      * @param TranslatorInterface $translator Translator service for header content.
@@ -75,7 +75,7 @@ final class HeaderContext
         public readonly ?string $sortableLinkDescClass,
         private readonly ?PageToken $pageToken,
         private readonly int|null $pageSize,
-        private readonly bool $enableMultiSort,
+        private readonly bool $multiSort,
         private readonly UrlConfig $urlConfig,
         private $urlCreator,
         private readonly TranslatorInterface $translator,
@@ -177,7 +177,7 @@ final class HeaderContext
         $order = $sort->getOrder();
 
         if (isset($order[$property])) {
-            if ($this->enableMultiSort) {
+            if ($this->multiSort) {
                 if ($order[$property] === 'asc') {
                     $order[$property] = 'desc';
                 } elseif (!empty($originalOrder) && count($order) === 1) {
@@ -196,7 +196,7 @@ final class HeaderContext
             } else {
                 unset($order[$property]);
             }
-        } elseif ($this->enableMultiSort) {
+        } elseif ($this->multiSort) {
             $order[$property] = 'asc';
         } else {
             $order = [$property => 'asc'];

--- a/src/GridView.php
+++ b/src/GridView.php
@@ -71,7 +71,7 @@ final class GridView extends BaseListView
     /**
      * @var bool Whether column grouping is enabled.
      */
-    private bool $isColumnGroupingEnabled = false;
+    private bool $columnGrouping = false;
 
     /**
      * @var string HTML content for empty cells.
@@ -398,10 +398,10 @@ final class GridView extends BaseListView
      *
      * @return self New instance with the column grouping enabled.
      */
-    public function enableColumnGrouping(bool $enabled = true): self
+    public function columnGrouping(bool $enabled = true): self
     {
         $new = clone $this;
-        $new->isColumnGroupingEnabled = $enabled;
+        $new->columnGrouping = $enabled;
         return $new;
     }
 
@@ -814,7 +814,7 @@ final class GridView extends BaseListView
             $filterRow = null;
         }
 
-        if ($this->isColumnGroupingEnabled) {
+        if ($this->columnGrouping) {
             $tags = [];
             foreach ($columns as $i => $column) {
                 $cell = $renderers[$i]->renderColumn($column, new Cell(), $globalContext);

--- a/src/GridView.php
+++ b/src/GridView.php
@@ -842,7 +842,7 @@ final class GridView extends BaseListView
                 $this->sortableLinkDescClass,
                 $this->keepPageOnSort ? $pageToken : null,
                 $pageSize,
-                $this->enableMultiSort,
+                $this->multiSort,
                 $this->urlConfig,
                 $this->urlCreator,
                 $this->translator,

--- a/src/GridView.php
+++ b/src/GridView.php
@@ -444,7 +444,7 @@ final class GridView extends BaseListView
      *
      * @return self New instance with the footer section visibility setting.
      */
-    public function enableFooter(bool $enabled): self
+    public function enableFooter(bool $enabled = true): self
     {
         $new = clone $this;
         $new->isFooterEnabled = $enabled;

--- a/tests/Column/DataColumnTest.php
+++ b/tests/Column/DataColumnTest.php
@@ -543,7 +543,7 @@ final class DataColumnTest extends TestCase
                         bodyClass: 'bodyClass'
                     ),
                 )
-                ->enableColumnGrouping()
+                ->columnGrouping()
                 ->dataReader(new IterableDataReader($this->data))
                 ->render()
         );

--- a/tests/GridView/BaseTest.php
+++ b/tests/GridView/BaseTest.php
@@ -119,7 +119,7 @@ final class BaseTest extends TestCase
                     new DataColumn(property: 'id', columnAttributes: ['class' => 'bg-primary']),
                     new DataColumn(property: 'name', columnAttributes: ['class' => 'bg-success']),
                 )
-                ->enableColumnGrouping()
+                ->columnGrouping()
                 ->id('w1-grid')
                 ->dataReader($this->createOffsetPaginator($this->data, 10))
                 ->render()
@@ -171,7 +171,7 @@ final class BaseTest extends TestCase
                     new DataColumn(property: 'name'),
                     new DataColumn(property: 'age'),
                 )
-                ->enableColumnGrouping()
+                ->columnGrouping()
                 ->id('w1-grid')
                 ->dataReader($this->createOffsetPaginator($this->data, 10))
                 ->render()

--- a/tests/GridView/ImmutableTest.php
+++ b/tests/GridView/ImmutableTest.php
@@ -56,7 +56,7 @@ final class ImmutableTest extends TestCase
         $this->assertNotSame($gridView, $gridView->afterRow(null));
         $this->assertNotSame($gridView, $gridView->beforeRow(null));
         $this->assertNotSame($gridView, $gridView->columns(new DataColumn()));
-        $this->assertNotSame($gridView, $gridView->enableColumnGrouping(false));
+        $this->assertNotSame($gridView, $gridView->columnGrouping(false));
         $this->assertNotSame($gridView, $gridView->emptyCell(''));
         $this->assertNotSame($gridView, $gridView->enableFooter(false));
         $this->assertNotSame($gridView, $gridView->footerRowAttributes([]));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ✔️

- Rename `enableMultiSort` to `multiSort`
- Rename `enableColumnGrouping` to `columnGrouping`
- Add default value for `enableFooter()` parameter