### PR TITLE
Add ability to not encode a `DataField` value

### DIFF
--- a/src/DetailView.php
+++ b/src/DetailView.php
@@ -338,7 +338,7 @@ final class DetailView extends Widget
                 'labelTag' => $labelTag,
                 'value' => $field->encodeValue
                     ? Html::encodeAttribute($this->renderValue($field->name, $field->value))
-                    : $this->renderValue($field->name, $field->value)
+                    : (string) $this->renderValue($field->name, $field->value)
                 ,
                 'valueAttributes' => $this->renderAttributes($valueAttributes),
                 'valueTag' => $valueTag,

--- a/src/DetailView.php
+++ b/src/DetailView.php
@@ -336,7 +336,10 @@ final class DetailView extends Widget
                 'label' => Html::encode($field->label === '' ? $field->name : $field->label),
                 'labelAttributes' => $this->renderAttributes($labelAttributes),
                 'labelTag' => $labelTag,
-                'value' => Html::encodeAttribute($this->renderValue($field->name, $field->value)),
+                'value' => $field->encodeValue
+                    ? Html::encodeAttribute($this->renderValue($field->name, $field->value))
+                    : $this->renderValue($field->name, $field->value)
+                ,
                 'valueAttributes' => $this->renderAttributes($valueAttributes),
                 'valueTag' => $valueTag,
             ];

--- a/src/Field/DataField.php
+++ b/src/Field/DataField.php
@@ -39,6 +39,8 @@ final class DataField
      * a function accepting data and returning the array.
      * Example array: `['class' => 'value', 'data-type' => 'text']`
      * Example closure: `fn($data) => ['class' => $data->status . '-value']`
+     *
+     * @param bool $encodeValue Whether the value is HTML encoded
      */
     public function __construct(
         public readonly string $name = '',
@@ -47,7 +49,8 @@ final class DataField
         public readonly string $labelTag = '',
         public readonly mixed $value = null,
         public readonly string $valueTag = '',
-        public readonly array|Closure $valueAttributes = []
+        public readonly array|Closure $valueAttributes = [],
+        public readonly bool $encodeValue = true,
     ) {
     }
 }

--- a/tests/DetailView/BaseTest.php
+++ b/tests/DetailView/BaseTest.php
@@ -19,12 +19,6 @@ final class BaseTest extends TestCase
 {
     use TestTrait;
 
-    /**
-     * @throws InvalidConfigException
-     * @throws NotFoundException
-     * @throws NotInstantiableException
-     * @throws CircularReferenceException
-     */
     public function testNonEncodedValue(): void
     {
         Assert::equalsWithoutLE(

--- a/tests/DetailView/BaseTest.php
+++ b/tests/DetailView/BaseTest.php
@@ -25,6 +25,47 @@ final class BaseTest extends TestCase
      * @throws NotInstantiableException
      * @throws CircularReferenceException
      */
+    public function testNonEncodedValue(): void
+    {
+        Assert::equalsWithoutLE(
+            <<<HTML
+            <div>
+            <dl>
+            <div>
+            <dt>id</dt>
+            <dd>1</dd>
+            </div>
+            <div>
+            <dt>value</dt>
+            <dd><pre>tests 1</pre></dd>
+            </div>
+            <div>
+            <dt>total</dt>
+            <dd>10</dd>
+            </div>
+            </dl>
+            </div>
+            HTML,
+            DetailView::widget()
+                ->fields(
+                    new DataField('id'),
+                    new DataField(
+                        name: 'value',
+                        encodeValue: false
+                    ),
+                    new DataField('total'),
+                )
+                ->data(['id' => 1, 'value' => '<pre>tests 1</pre>', 'total' => '10'])
+                ->render(),
+        );
+    }
+
+    /**
+     * @throws InvalidConfigException
+     * @throws NotFoundException
+     * @throws NotInstantiableException
+     * @throws CircularReferenceException
+     */
     public function testAttributes(): void
     {
         Assert::equalsWithoutLE(


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌

To allow - for example - the DataField value to contain HTML