### PR TITLE
Raise code coverage `100%` to `UrlCreator` and `UrlParameterProvider` classes.

### DIFF
--- a/tests/YiiRouter/UrlCreatorTest.php
+++ b/tests/YiiRouter/UrlCreatorTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Yii\DataView\Tests\YiiRouter;
+
+use PHPUnit\Framework\TestCase;
+use Yiisoft\Router\UrlGeneratorInterface;
+use Yiisoft\Yii\DataView\YiiRouter\UrlCreator;
+
+final class UrlCreatorTest extends TestCase
+{
+	public function testInvoke(): void
+	{
+		$arguments = ['page' => 2];
+		$queryParameters = ['sort' => 'name', 'dir' => 'asc'];
+		$expectedUrl = '/users?page=2&sort=name&dir=asc';
+
+        $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
+
+		$urlGenerator
+			->expects($this->once())
+			->method('generateFromCurrent')
+			->with($arguments, $queryParameters)
+			->willReturn($expectedUrl);
+
+        /** @var UrlGeneratorInterface $urlGenerator */
+		$urlCreator = new UrlCreator($urlGenerator);
+
+		$this->assertSame($expectedUrl, $urlCreator($arguments, $queryParameters));
+	}
+
+	public function testInvokeWithEmptyParameters(): void
+	{
+		$expectedUrl = '/users';
+
+        $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
+
+		$urlGenerator->expects($this->once())->method('generateFromCurrent')->with([], [])->willReturn($expectedUrl);
+
+        /** @var UrlGeneratorInterface $urlGenerator */
+		$urlCreator = new UrlCreator($urlGenerator);
+
+		$this->assertSame($expectedUrl, $urlCreator([], []));
+	}
+
+	public function testInvokeWithOnlyArguments(): void
+	{
+		$arguments = ['id' => 123];
+		$expectedUrl = '/users/123';
+
+        $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
+
+		$urlGenerator
+			->expects($this->once())
+			->method('generateFromCurrent')
+			->with($arguments, [])
+			->willReturn($expectedUrl);
+
+        /** @var UrlGeneratorInterface $urlGenerator */
+		$urlCreator = new UrlCreator($urlGenerator);
+
+		$this->assertSame($expectedUrl, $urlCreator($arguments, []));
+	}
+
+	public function testInvokeWithOnlyQueryParameters(): void
+	{
+		$queryParameters = ['filter' => 'active'];
+		$expectedUrl = '/users?filter=active';
+
+        $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
+
+		$urlGenerator
+			->expects($this->once())
+			->method('generateFromCurrent')
+			->with([], $queryParameters)
+			->willReturn($expectedUrl);
+
+        /** @var UrlGeneratorInterface $urlGenerator */
+		$urlCreator = new UrlCreator($urlGenerator);
+
+		$this->assertSame($expectedUrl, $urlCreator([], $queryParameters));
+	}
+}

--- a/tests/YiiRouter/UrlCreatorTest.php
+++ b/tests/YiiRouter/UrlCreatorTest.php
@@ -10,75 +10,75 @@ use Yiisoft\Yii\DataView\YiiRouter\UrlCreator;
 
 final class UrlCreatorTest extends TestCase
 {
-	public function testInvoke(): void
-	{
-		$arguments = ['page' => 2];
-		$queryParameters = ['sort' => 'name', 'dir' => 'asc'];
-		$expectedUrl = '/users?page=2&sort=name&dir=asc';
+    public function testInvoke(): void
+    {
+        $arguments = ['page' => 2];
+        $queryParameters = ['sort' => 'name', 'dir' => 'asc'];
+        $expectedUrl = '/users?page=2&sort=name&dir=asc';
 
         $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
 
-		$urlGenerator
-			->expects($this->once())
-			->method('generateFromCurrent')
-			->with($arguments, $queryParameters)
-			->willReturn($expectedUrl);
+        $urlGenerator
+            ->expects($this->once())
+            ->method('generateFromCurrent')
+            ->with($arguments, $queryParameters)
+            ->willReturn($expectedUrl);
 
         /** @var UrlGeneratorInterface $urlGenerator */
-		$urlCreator = new UrlCreator($urlGenerator);
+        $urlCreator = new UrlCreator($urlGenerator);
 
-		$this->assertSame($expectedUrl, $urlCreator($arguments, $queryParameters));
-	}
+        $this->assertSame($expectedUrl, $urlCreator($arguments, $queryParameters));
+    }
 
-	public function testInvokeWithEmptyParameters(): void
-	{
-		$expectedUrl = '/users';
+    public function testInvokeWithEmptyParameters(): void
+    {
+        $expectedUrl = '/users';
 
         $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
 
-		$urlGenerator->expects($this->once())->method('generateFromCurrent')->with([], [])->willReturn($expectedUrl);
+        $urlGenerator->expects($this->once())->method('generateFromCurrent')->with([], [])->willReturn($expectedUrl);
 
         /** @var UrlGeneratorInterface $urlGenerator */
-		$urlCreator = new UrlCreator($urlGenerator);
+        $urlCreator = new UrlCreator($urlGenerator);
 
-		$this->assertSame($expectedUrl, $urlCreator([], []));
-	}
+        $this->assertSame($expectedUrl, $urlCreator([], []));
+    }
 
-	public function testInvokeWithOnlyArguments(): void
-	{
-		$arguments = ['id' => 123];
-		$expectedUrl = '/users/123';
+    public function testInvokeWithOnlyArguments(): void
+    {
+        $arguments = ['id' => 123];
+        $expectedUrl = '/users/123';
 
         $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
 
-		$urlGenerator
-			->expects($this->once())
-			->method('generateFromCurrent')
-			->with($arguments, [])
-			->willReturn($expectedUrl);
+        $urlGenerator
+            ->expects($this->once())
+            ->method('generateFromCurrent')
+            ->with($arguments, [])
+            ->willReturn($expectedUrl);
 
         /** @var UrlGeneratorInterface $urlGenerator */
-		$urlCreator = new UrlCreator($urlGenerator);
+        $urlCreator = new UrlCreator($urlGenerator);
 
-		$this->assertSame($expectedUrl, $urlCreator($arguments, []));
-	}
+        $this->assertSame($expectedUrl, $urlCreator($arguments, []));
+    }
 
-	public function testInvokeWithOnlyQueryParameters(): void
-	{
-		$queryParameters = ['filter' => 'active'];
-		$expectedUrl = '/users?filter=active';
+    public function testInvokeWithOnlyQueryParameters(): void
+    {
+        $queryParameters = ['filter' => 'active'];
+        $expectedUrl = '/users?filter=active';
 
         $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
 
-		$urlGenerator
-			->expects($this->once())
-			->method('generateFromCurrent')
-			->with([], $queryParameters)
-			->willReturn($expectedUrl);
+        $urlGenerator
+            ->expects($this->once())
+            ->method('generateFromCurrent')
+            ->with([], $queryParameters)
+            ->willReturn($expectedUrl);
 
         /** @var UrlGeneratorInterface $urlGenerator */
-		$urlCreator = new UrlCreator($urlGenerator);
+        $urlCreator = new UrlCreator($urlGenerator);
 
-		$this->assertSame($expectedUrl, $urlCreator([], $queryParameters));
-	}
+        $this->assertSame($expectedUrl, $urlCreator([], $queryParameters));
+    }
 }

--- a/tests/YiiRouter/UrlParameterProviderTest.php
+++ b/tests/YiiRouter/UrlParameterProviderTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Yii\DataView\Tests\YiiRouter;
+
+use PHPUnit\Framework\TestCase;
+use Yiisoft\Router\CurrentRoute;
+use Yiisoft\Router\Route;
+use Yiisoft\Yii\DataView\UrlParameterType;
+use Yiisoft\Yii\DataView\YiiRouter\UrlParameterProvider;
+
+final class UrlParameterProviderTest extends TestCase
+{
+    public function testGetNonExistentParameter(): void
+    {
+        $paramName = 'nonexistent';
+
+        $currentRoute = new CurrentRoute();
+        $currentRoute->setRouteWithArguments(Route::get('/test')->name('test'), [$paramName => null]);
+
+        /** @var CurrentRoute $currentRoute */
+        $provider = new UrlParameterProvider($currentRoute);
+
+        $this->assertNull($provider->get($paramName, UrlParameterType::PATH));
+        $this->assertNull($provider->get($paramName, UrlParameterType::QUERY));
+    }
+
+    public function testGetRouteWithArgument(): void
+    {
+        $paramName = 'id';
+        $paramValue = '42';
+
+        $currentRoute = new CurrentRoute();
+        $currentRoute->setRouteWithArguments(Route::get('/test')->name('test'), [$paramName => $paramValue]);
+
+        /** @var CurrentRoute $currentRoute */
+        $provider = new UrlParameterProvider($currentRoute);
+
+        $this->assertSame($paramValue, $provider->get($paramName, UrlParameterType::PATH));
+    }
+
+    public function testGetRouteWithQueryParameter(): void
+    {
+        $_GET = [];
+
+        $paramName = 'sort';
+        $paramValue = 'name';
+
+        $_GET[$paramName] = $paramValue;
+
+        $currentRoute = new CurrentRoute();
+        $currentRoute->setRouteWithArguments(Route::get('/test')->name('test'), []);
+
+        /** @var CurrentRoute $currentRoute */
+        $provider = new UrlParameterProvider($currentRoute);
+
+        $this->assertSame($paramValue, $provider->get($paramName, UrlParameterType::QUERY));
+
+        $_GET = [];
+    }
+
+    public function testGetWithInvalidType(): void
+    {
+        $paramName = 'id';
+
+        $currentRoute = new CurrentRoute();
+        $currentRoute->setRouteWithArguments(Route::get('/test')->name('test'), [$paramName => '42']);
+
+        /** @var CurrentRoute $currentRoute */
+        $provider = new UrlParameterProvider($currentRoute);
+
+        $this->assertNull($provider->get($paramName, 0));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
