### PR TITLE
Add caption tag support for GridView table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.0.1 under development
 
+- New #329: Add caption support for GridView (@Roc755)
 - Enh #328: Explicitly import constants in "use" section (@mspirkov)
 - Enh #331: Bump minimal `yiisoft/html` version to `3.13` and add support for `^4.0` (@vjik)
 

--- a/docs/en/guide/gridview.md
+++ b/docs/en/guide/gridview.md
@@ -285,6 +285,21 @@ use Yiisoft\Html\Html;use Yiisoft\Yii\DataView\GridView\GridView;
 ?>
 ```
 
+### Caption
+
+You can add a caption to the grid table using the `caption()` method:
+
+```php
+use Yiisoft\Yii\DataView\GridView\GridView;
+
+echo GridView::widget()
+    ->caption('List of Users');
+```
+
+The method accepts `string`, `Stringable`, or `null`. Pass `null` to remove the caption.
+
+The caption is rendered as a `<caption>` tag inside the `<table>` element.
+
 ## Custom Column Renderers
 
 You can add custom column renderers for special rendering needs:

--- a/src/GridView/GridView.php
+++ b/src/GridView/GridView.php
@@ -979,7 +979,7 @@ final class GridView extends BaseListView
 
         $caption = $this->caption === null
             ? ''
-            : Html::tag('caption')->content($this->caption)->render() . "\n";
+            : Html::tag('caption', $this->caption) . "\n";
 
         return
             $filtersForm

--- a/src/GridView/GridView.php
+++ b/src/GridView/GridView.php
@@ -120,6 +120,11 @@ final class GridView extends BaseListView
     private array $tableAttributes = [];
 
     /**
+     * @var string|Stringable|null Content for the `caption` tag. `null` means no caption.
+     */
+    private string|Stringable|null $caption = null;
+
+    /**
      * @var array HTML attributes for the tbody tag.
      */
     private array $tbodyAttributes = [];
@@ -555,6 +560,20 @@ final class GridView extends BaseListView
     {
         $new = clone $this;
         $new->tableAttributes = $attributes;
+        return $new;
+    }
+
+    /**
+     * Return new instance with the content for the `caption` tag.
+     *
+     * @param string|Stringable|null $content Caption content. Set to `null` to remove caption.
+     *
+     * @return self New instance with the caption content.
+     */
+    public function caption(string|Stringable|null $content): self
+    {
+        $new = clone $this;
+        $new->caption = $content;
         return $new;
     }
 

--- a/src/GridView/GridView.php
+++ b/src/GridView/GridView.php
@@ -979,7 +979,7 @@ final class GridView extends BaseListView
 
         $caption = $this->caption === null
             ? ''
-            : Html::tag('caption')->content((string) $this->caption)->render() . "\n";
+            : Html::tag('caption')->content($this->caption)->render() . "\n";
 
         return
             $filtersForm

--- a/src/GridView/GridView.php
+++ b/src/GridView/GridView.php
@@ -977,10 +977,15 @@ final class GridView extends BaseListView
                 ->render()
             : Html::tbody($this->tbodyAttributes)->rows(...$rows)->render();
 
+        $caption = $this->caption === null
+            ? ''
+            : Html::tag('caption')->content((string) $this->caption)->render() . "\n";
+
         return
             $filtersForm
             . Html::tag('table', attributes: $this->tableAttributes)->open()
             . "\n"
+            . $caption
             . implode("\n", $blocks)
             . "\n"
             . '</table>';

--- a/tests/GridView/GridViewTest.php
+++ b/tests/GridView/GridViewTest.php
@@ -536,6 +536,25 @@ final class GridViewTest extends TestCase
         );
     }
 
+    public function testCaption(): void
+    {
+        $html = $this->createGridView()
+            ->caption('Users list')
+            ->columns(
+                new DataColumn('id'),
+            )
+            ->render();
+
+        $this->assertStringContainsString(
+            <<<HTML
+            <table>
+            <caption>Users list</caption>
+            <thead>
+            HTML,
+            $html,
+        );
+    }
+
     public function testAddTableClass(): void
     {
         $html = $this->createGridView()
@@ -2010,6 +2029,7 @@ final class GridViewTest extends TestCase
         $this->assertNotSame($gridView, $gridView->headerRowAttributes([]));
         $this->assertNotSame($gridView, $gridView->bodyRowAttributes([]));
         $this->assertNotSame($gridView, $gridView->tableAttributes([]));
+        $this->assertNotSame($gridView, $gridView->caption('test'));
         $this->assertNotSame($gridView, $gridView->addTableClass('test'));
         $this->assertNotSame($gridView, $gridView->tableClass('test'));
         $this->assertNotSame($gridView, $gridView->tbodyAttributes([]));


### PR DESCRIPTION
## Summary
- add `GridView::caption(string|Stringable|null $content)` to configure table caption
- render `<caption>` inside `<table>` before sections
- add GridView tests for caption rendering and immutability

Closes #319
