### PR TITLE
Add includeRequestParams to ActionColumnUrlConfig (#15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.1.1 under development
 
-- no changes in this release.
+- Enh #332: Add `includeRequestParams` option to `ActionColumnUrlConfig` to preserve filters, sorting and pagination in action button URLs (@WarLikeLaux)
 
 ## 1.1.0 March 21, 2026
 

--- a/src/YiiRouter/ActionColumnUrlConfig.php
+++ b/src/YiiRouter/ActionColumnUrlConfig.php
@@ -21,6 +21,10 @@ final class ActionColumnUrlConfig
      * @psalm-param array<string,scalar|Stringable|null> $arguments
      * @param array $queryParameters Additional query parameters to append to the URL.
      * @param UrlParameterType|null $primaryKeyParameterType How to include the primary key in the URL.
+     * @param bool $includeRequestParams Whether to include current request query parameters
+     * (such as filters, sorting and pagination) in generated URLs. When `true`, clicking
+     * an action button preserves the current grid state (filters, sort, page) so that
+     * after the action completes and a redirect happens, the user returns to the same view.
      */
     public function __construct(
         public readonly ?string $primaryKey = null,
@@ -28,5 +32,6 @@ final class ActionColumnUrlConfig
         public readonly array $arguments = [],
         public readonly array $queryParameters = [],
         public readonly ?UrlParameterType $primaryKeyParameterType = null,
+        public readonly bool $includeRequestParams = false,
     ) {}
 }

--- a/src/YiiRouter/ActionColumnUrlCreator.php
+++ b/src/YiiRouter/ActionColumnUrlCreator.php
@@ -12,6 +12,7 @@ use Yiisoft\Yii\DataView\GridView\Column\Base\DataContext;
 use Yiisoft\Yii\DataView\Url\UrlParameterType;
 
 use function is_object;
+use function is_string;
 
 /**
  * URL creator for action columns in `GridView`.
@@ -67,6 +68,15 @@ final class ActionColumnUrlCreator
 
         $arguments = $config->arguments;
         $queryParameters = $config->queryParameters;
+
+        if ($config->includeRequestParams) {
+            $requestParams = array_filter(
+                $_GET,
+                static fn($value): bool => is_string($value),
+            );
+            $queryParameters = array_merge($requestParams, $queryParameters);
+        }
+
         switch ($primaryKeyParameterType) {
             case UrlParameterType::Path:
                 $arguments = array_merge($arguments, [$primaryKey => (string) $primaryKeyValue]);

--- a/src/YiiRouter/ActionColumnUrlCreator.php
+++ b/src/YiiRouter/ActionColumnUrlCreator.php
@@ -72,7 +72,7 @@ final class ActionColumnUrlCreator
         if ($config->includeRequestParams) {
             $requestParams = array_filter(
                 $_GET,
-                static fn($value): bool => is_string($value),
+                is_string(...),
             );
             $queryParameters = array_merge($requestParams, $queryParameters);
         }

--- a/tests/YiiRouter/ActionColumnUrlCreatorTest.php
+++ b/tests/YiiRouter/ActionColumnUrlCreatorTest.php
@@ -84,6 +84,148 @@ final class ActionColumnUrlCreatorTest extends TestCase
         $this->assertSame('/post/view/2/', $result);
     }
 
+    public function testIncludeRequestParams(): void
+    {
+        $originalGet = $_GET;
+        $_GET = ['sort' => '-name', 'filter' => 'active', 'page' => '3'];
+
+        try {
+            $routeMain = Route::get('/post')->name('post');
+            $routeView = Route::get('/post/view')->name('post/view');
+            $currentRoute = new CurrentRoute();
+            $currentRoute->setRouteWithArguments($routeMain, []);
+            $urlGenerator = new UrlGenerator(
+                new RouteCollection(
+                    (new RouteCollector())->addRoute($routeMain, $routeView),
+                ),
+                $currentRoute,
+            );
+
+            $context = TestHelper::createDataContext(
+                column: new ActionColumn(
+                    urlConfig: new ActionColumnUrlConfig(includeRequestParams: true),
+                ),
+                data: ['id' => 2],
+            );
+            $urlCreator = new ActionColumnUrlCreator(
+                $urlGenerator,
+                $currentRoute,
+            );
+
+            $result = ($urlCreator)('view', $context);
+
+            $this->assertSame('/post/view?sort=-name&filter=active&page=3&id=2', $result);
+        } finally {
+            $_GET = $originalGet;
+        }
+    }
+
+    public function testIncludeRequestParamsFiltersNonStringValues(): void
+    {
+        $originalGet = $_GET;
+        $_GET = ['sort' => '-name', 'arr' => ['a', 'b'], 'num' => 42];
+
+        try {
+            $routeMain = Route::get('/post')->name('post');
+            $routeView = Route::get('/post/view')->name('post/view');
+            $currentRoute = new CurrentRoute();
+            $currentRoute->setRouteWithArguments($routeMain, []);
+            $urlGenerator = new UrlGenerator(
+                new RouteCollection(
+                    (new RouteCollector())->addRoute($routeMain, $routeView),
+                ),
+                $currentRoute,
+            );
+
+            $context = TestHelper::createDataContext(
+                column: new ActionColumn(
+                    urlConfig: new ActionColumnUrlConfig(includeRequestParams: true),
+                ),
+                data: ['id' => 2],
+            );
+            $urlCreator = new ActionColumnUrlCreator(
+                $urlGenerator,
+                $currentRoute,
+            );
+
+            $result = ($urlCreator)('view', $context);
+
+            $this->assertSame('/post/view?sort=-name&id=2', $result);
+        } finally {
+            $_GET = $originalGet;
+        }
+    }
+
+    public function testIncludeRequestParamsDisabledByDefault(): void
+    {
+        $originalGet = $_GET;
+        $_GET = ['sort' => '-name', 'filter' => 'active'];
+
+        try {
+            $routeMain = Route::get('/post')->name('post');
+            $routeView = Route::get('/post/view')->name('post/view');
+            $currentRoute = new CurrentRoute();
+            $currentRoute->setRouteWithArguments($routeMain, []);
+            $urlGenerator = new UrlGenerator(
+                new RouteCollection(
+                    (new RouteCollector())->addRoute($routeMain, $routeView),
+                ),
+                $currentRoute,
+            );
+
+            $context = TestHelper::createDataContext(data: ['id' => 2]);
+            $urlCreator = new ActionColumnUrlCreator(
+                $urlGenerator,
+                $currentRoute,
+            );
+
+            $result = ($urlCreator)('view', $context);
+
+            $this->assertSame('/post/view?id=2', $result);
+        } finally {
+            $_GET = $originalGet;
+        }
+    }
+
+    public function testIncludeRequestParamsWithExplicitQueryParameters(): void
+    {
+        $originalGet = $_GET;
+        $_GET = ['sort' => '-name', 'page' => '3'];
+
+        try {
+            $routeMain = Route::get('/post')->name('post');
+            $routeView = Route::get('/post/view')->name('post/view');
+            $currentRoute = new CurrentRoute();
+            $currentRoute->setRouteWithArguments($routeMain, []);
+            $urlGenerator = new UrlGenerator(
+                new RouteCollection(
+                    (new RouteCollector())->addRoute($routeMain, $routeView),
+                ),
+                $currentRoute,
+            );
+
+            $context = TestHelper::createDataContext(
+                column: new ActionColumn(
+                    urlConfig: new ActionColumnUrlConfig(
+                        queryParameters: ['extra' => 'value'],
+                        includeRequestParams: true,
+                    ),
+                ),
+                data: ['id' => 2],
+            );
+            $urlCreator = new ActionColumnUrlCreator(
+                $urlGenerator,
+                $currentRoute,
+            );
+
+            $result = ($urlCreator)('view', $context);
+
+            $this->assertSame('/post/view?sort=-name&page=3&extra=value&id=2', $result);
+        } finally {
+            $_GET = $originalGet;
+        }
+    }
+
     public function testCustomPrimaryKey(): void
     {
         $routeMain = Route::get('/post')->name('post');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Tests added?  | ✔️
| Breaks BC?    | ❌
| Fixed issues  | #15

## What does this PR do?

Add `includeRequestParams` option to `ActionColumnUrlConfig` so that action button URLs can preserve current request query parameters (filters, sorting, pagination).

### Coverage

| File | Tests | Lines | MSI |
|---|---|---|---|
| ActionColumnUrlConfig.php | 8 | 1/1 (100%) | 100% (1/1) |
| ActionColumnUrlCreator.php | 4 → 8 | 31/31 (100%) | 80% → 83% (26/31) |