### PR TITLE
Pass `DataContext` to `callable` buttons in `ActionColumn`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.1.1 under development
 
-- no changes in this release.
+- Enh #338: Pass `DataContext` to `callable` buttons in `ActionColumn` (@vjik)
 
 ## 1.1.0 March 21, 2026
 

--- a/docs/en/guide/gridview.md
+++ b/docs/en/guide/gridview.md
@@ -78,6 +78,7 @@ ActionColumn displays action buttons (e.g., view, edit, delete):
 ```php
 use Yiisoft\Html\Html;
 use Yiisoft\Yii\DataView\GridView\Column\ActionColumn;
+use Yiisoft\Yii\DataView\GridView\Column\Base\DataContext;
 
 $column = new ActionColumn(
     buttons: [
@@ -87,10 +88,10 @@ $column = new ActionColumn(
                 return '/posts/view' . $data->id; 
             }
         ),
-        'edit' => function (string $url): string {
+        'edit' => function (string $url, DataContext $context): string {
             return (string) Html::a('Edit', $url);
         },
-        'delete' => function (string $url): string {
+        'delete' => function (string $url, DataContext $context): string {
             return (string) Html::a('Delete', $url);
         },
     ],

--- a/src/GridView/Column/ActionColumn.php
+++ b/src/GridView/Column/ActionColumn.php
@@ -14,7 +14,7 @@ use Yiisoft\Yii\DataView\GridView\GridView;
  * the items.
  *
  * @psalm-type UrlCreator = callable(string, DataContext): string
- * @psalm-type ButtonRenderer = ActionButton|callable(string): string
+ * @psalm-type ButtonRenderer = ActionButton|callable(string, DataContext): string
  * @psalm-type TContent = scalar|Stringable|null|callable(array|object, DataContext): string
  */
 final class ActionColumn implements ColumnInterface
@@ -36,7 +36,8 @@ final class ActionColumn implements ColumnInterface
      * @param string|null $footer The footer cell content.
      * @param mixed $content The content to be rendered in each data cell.
      * @param array|null $buttons Array of buttons. Keys are button names. Values are either instances
-     * of {@see ActionButton} or a callable with the following signature: `function(string $url): string`.
+     * of {@see ActionButton} or a callable with the following signature:
+     * `function(string $url, DataContext $context): string`.
      * @param array|null $visibleButtons Array of button visibility rules.
      * @param array $columnAttributes HTML attributes for the column cells.
      * @param array $headerAttributes HTML attributes for the header cell.

--- a/src/GridView/Column/ActionColumnRenderer.php
+++ b/src/GridView/Column/ActionColumnRenderer.php
@@ -154,7 +154,7 @@ final class ActionColumnRenderer implements ColumnRendererInterface
     {
         if (is_callable($button)) {
             $url = $this->createUrl($name, $context);
-            return $button($url);
+            return $button($url, $context);
         }
 
         if ($button->content instanceof Closure) {

--- a/tests/GridView/Column/ActionColumnTest.php
+++ b/tests/GridView/Column/ActionColumnTest.php
@@ -267,7 +267,7 @@ final class ActionColumnTest extends TestCase
                 new ActionColumn(
                     buttons: [
                         'view' => new ActionButton('V', '#view'),
-                        'send' => new ActionButton('S', '#send', title: 'Send to…'),
+                        'send' => static fn(string $url, DataContext $context): string => '<a href="' . $url . '">S ' . $context->data['slug'] . '</a>',
                         'edit' => static fn(string $url) => '<a href="' . $url . '">EDIT</a>',
                         'delete' => new ActionButton(
                             content: static fn(array $data, DataContext $context) => 'Del ' . $data['id'],
@@ -284,31 +284,9 @@ final class ActionColumnTest extends TestCase
             <<<HTML
             <td>
             <a href="#view">V</a>
-            <a title="Send to…" href="#send">S</a>
+            <a href="/send/1">S item1</a>
             <a href="/edit/1">EDIT</a>
             <a data-id="id-1" class="red1" href="/confirm-delete/1">Del 1</a>
-            </td>
-            HTML,
-            $html,
-        );
-    }
-
-    public function testCallableButtonReceivesDataContext(): void
-    {
-        $html = $this->createGridView([['id' => 1, 'slug' => 'item1']])
-            ->columns(
-                new ActionColumn(
-                    buttons: [
-                        'edit' => static fn(string $url, DataContext $context): string => '<a href="' . $url . '">EDIT ' . $context->data['slug'] . '</a>',
-                    ],
-                ),
-            )
-            ->render();
-
-        $this->assertStringContainsString(
-            <<<HTML
-            <td>
-            <a href="/edit/1">EDIT item1</a>
             </td>
             HTML,
             $html,

--- a/tests/GridView/Column/ActionColumnTest.php
+++ b/tests/GridView/Column/ActionColumnTest.php
@@ -293,6 +293,28 @@ final class ActionColumnTest extends TestCase
         );
     }
 
+    public function testCallableButtonReceivesDataContext(): void
+    {
+        $html = $this->createGridView([['id' => 1, 'slug' => 'item1']])
+            ->columns(
+                new ActionColumn(
+                    buttons: [
+                        'edit' => static fn(string $url, DataContext $context): string => '<a href="' . $url . '">EDIT ' . $context->data['slug'] . '</a>',
+                    ],
+                ),
+            )
+            ->render();
+
+        $this->assertStringContainsString(
+            <<<HTML
+            <td>
+            <a href="/edit/1">EDIT item1</a>
+            </td>
+            HTML,
+            $html,
+        );
+    }
+
     #[TestWith(['<a title="View" href="#">V</a>', true])]
     #[TestWith(['<a class="red" title="View" href="#">V</a>', false])]
     public function testButtonOverrideAttribute(string $expected, bool $override): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
Fix #336 
