### PR TITLE
Add DropdownFilter::submitOnChange() to allow disabling inline onChange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## 1.1.1 under development
 
 - Enh #338: Pass `DataContext` to `callable` buttons in `ActionColumn` (@vjik)
+- Bug #344: Add `DropdownFilter::submitOnChange()` to allow disabling the inline
+  `onChange="this.form.submit()"` handler, which a Content Security Policy `script-src`
+  without `unsafe-inline` silently blocks (@rossaddison)
 
 ## 1.1.0 March 21, 2026
 

--- a/src/Filter/Widget/DropdownFilter.php
+++ b/src/Filter/Widget/DropdownFilter.php
@@ -15,6 +15,7 @@ use Yiisoft\Html\Tag\Select;
 final class DropdownFilter extends FilterWidget
 {
     private ?Select $select = null;
+    private bool $submitOnChange = true;
 
     /**
      * Sets the options data for the dropdown.
@@ -118,6 +119,31 @@ final class DropdownFilter extends FilterWidget
     }
 
     /**
+     * Whether to render an inline `onChange="this.form.submit()"` attribute that automatically
+     * submits the containing form when the dropdown's value changes. Enabled by default.
+     *
+     * Under a Content Security Policy `script-src` directive that does not include
+     * `unsafe-inline` — the standard hardening recommendation, and required for any serious XSS
+     * mitigation — browsers block this inline handler outright. Selecting an option then does
+     * nothing, silently: no exception is thrown anywhere in the application, the only signal is
+     * a CSP violation logged to the browser console.
+     *
+     * Disable it with `submitOnChange(false)` and wire up your own CSP-safe submission instead,
+     * for example a delegated `change` listener in an external script targeting a `class` or
+     * `data-*` marker set via {@see addAttributes()}.
+     *
+     * @param bool $enabled Whether to render the inline auto-submit handler.
+     *
+     * @return self New instance with the given auto-submit setting.
+     */
+    public function submitOnChange(bool $enabled): self
+    {
+        $new = clone $this;
+        $new->submitOnChange = $enabled;
+        return $new;
+    }
+
+    /**
      * Renders the dropdown filter with the given context.
      *
      * @param Context $context The filter context.
@@ -128,8 +154,11 @@ final class DropdownFilter extends FilterWidget
     {
         $select = $this->getSelect()
             ->name($context->property)
-            ->form($context->formId)
-            ->attribute('onChange', 'this.form.submit()');
+            ->form($context->formId);
+
+        if ($this->submitOnChange) {
+            $select = $select->attribute('onChange', 'this.form.submit()');
+        }
 
         if ($context->value !== null) {
             $select = $select->value($context->value);

--- a/tests/Filter/Widget/DropdownFilterTest.php
+++ b/tests/Filter/Widget/DropdownFilterTest.php
@@ -62,6 +62,52 @@ final class DropdownFilterTest extends TestCase
         );
     }
 
+    public function testSubmitOnChangeDisabled(): void
+    {
+        $filter = DropdownFilter::widget()
+            ->optionsData(['active' => 'Active'])
+            ->submitOnChange(false);
+        $context = new Context('status', 'active', 'filter-form');
+
+        $html = $filter->renderFilter($context);
+
+        $this->assertSame(
+            <<<HTML
+            <select name="status" form="filter-form">
+            <option value></option>
+            <option value="active" selected>Active</option>
+            </select>
+            HTML,
+            $html,
+        );
+    }
+
+    public function testSubmitOnChangeExplicitlyEnabled(): void
+    {
+        $filter = DropdownFilter::widget()
+            ->optionsData(['active' => 'Active'])
+            ->submitOnChange(false)
+            ->submitOnChange(true);
+        $context = new Context('status', null, 'filter-form');
+
+        $html = $filter->renderFilter($context);
+
+        $this->assertStringContainsString('onChange="this.form.submit()"', $html);
+    }
+
+    public function testSubmitOnChangeDisabledCanStillBeCombinedWithCustomAttributes(): void
+    {
+        $filter = DropdownFilter::widget()
+            ->addAttributes(['data-role' => 'auto-submit-select'])
+            ->submitOnChange(false);
+        $context = new Context('status', null, 'filter-form');
+
+        $html = $filter->renderFilter($context);
+
+        $this->assertStringContainsString('data-role="auto-submit-select"', $html);
+        $this->assertStringNotContainsString('onChange', $html);
+    }
+
     public function testAddAttributes(): void
     {
         $filter = DropdownFilter::widget()
@@ -167,5 +213,6 @@ final class DropdownFilterTest extends TestCase
         $this->assertNotSame($filter, $filter->attributes([]));
         $this->assertNotSame($filter, $filter->addClass());
         $this->assertNotSame($filter, $filter->class());
+        $this->assertNotSame($filter, $filter->submitOnChange(false));
     }
 }


### PR DESCRIPTION
Fixes #344.

## Problem

`DropdownFilter::renderFilter()` unconditionally renders an inline
`onChange="this.form.submit()"` attribute. Under a Content Security Policy
`script-src` directive without `unsafe-inline` (the standard hardening
recommendation, and required for any serious XSS mitigation), browsers
block this handler outright. Selecting an option then does nothing,
silently — no exception is thrown anywhere in the consuming application,
the only signal is a CSP violation logged to the browser console:

```
Executing inline event handler violates the following Content Security
Policy directive: "script-src 'self'". Either the 'unsafe-inline' keyword,
a hash ('sha256-...'), or a nonce ('nonce-...') is required to enable
inline execution...
```

We hit this in production after an unrelated CSP-hardening pass tightened
our own app's `script-src` — every `DropdownFilter` column filter across
several `GridView` pages silently stopped filtering, and because the
failure produces no exception it was only caught by users noticing
dropdowns "not working," not by any automated test.

Since `DropdownFilter` is `final`, there was previously no way to work
around this from consuming code short of forking the package.

## Fix

Adds `submitOnChange(bool $enabled): self` — an immutable fluent method
consistent with the class's existing API (`addAttributes()`, `attributes()`,
`addClass()`, `class()`). Defaults to `true`, so **existing output is
byte-identical for every consumer not calling the new method** — this is
a purely additive, non-breaking change.

CSP-strict consumers call `->submitOnChange(false)` to drop the inline
attribute, then wire their own submission however suits their app — for
example a delegated `change` listener in an external script targeting a
`class`/`data-*` marker set via the existing `addAttributes()`:

```php
DropdownFilter::widget()
    ->addAttributes(['class' => 'my-filter-select'])
    ->submitOnChange(false)
    ->optionsData($options);
```

```js
document.addEventListener('change', (e) => {
    if (e.target.matches('select.my-filter-select')) {
        e.target.form?.submit();
    }
});
```

## Testing

- 3 new test cases in `DropdownFilterTest`: disabled (no `onChange`
  rendered), explicitly re-enabled, and combined with `addAttributes()`.
- `testImmutability()` extended to cover the new method.
- Full suite: 514/514 passing (`vendor/bin/phpunit --no-coverage`).
- `vendor/bin/psalm --no-cache`: no errors.
- `vendor/bin/php-cs-fixer fix --dry-run --diff`: 0 files need fixing.
- `vendor/bin/rector process --dry-run`: no changes suggested.
- CHANGELOG entry added under `1.1.1 under development`.
