### PR TITLE
Fix PCOV coverage path in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
     secrets:
       codecovToken: ${{ secrets.CODECOV_TOKEN }}
     with:
-      ini-values: pcov.directory=$GITHUB_WORKSPACE, pcov.exclude=#^(?!($GITHUB_WORKSPACE/config/|$GITHUB_WORKSPACE/src/)).*#
+      ini-values: pcov.directory=${{ github.workspace }}, pcov.exclude=#(^|[\\/])(vendor|tests)([\\/]|$)#
       extensions: intl
       os: >-
         ['ubuntu-latest', 'windows-latest']


### PR DESCRIPTION
## Summary
- expand `pcov.directory` with `${{ github.workspace }}` so PCOV instruments the checked-out repository instead of a literal `$GITHUB_WORKSPACE` path
- replace the absolute-path negative PCOV regex with a cross-platform separator-aware exclude for `vendor/` and `tests/`
- rely on PHPUnit `<source>` includes to keep reported coverage scoped to `config/` and `src/`

## Why
The reusable PHPUnit workflow passes `ini-values` directly to `shivammathur/setup-php`. Because this is an action input, `$GITHUB_WORKSPACE` is not expanded by a shell. PCOV was therefore configured with a literal directory named `$GITHUB_WORKSPACE`, producing an effectively empty Clover report that Codecov accepted as 0% coverage.

The exclude regex no longer embeds `${{ github.workspace }}` because that path can contain backslashes on Windows.

## Verification
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/build.yml"); puts "ok"'`
- `git diff --check`
