### PR TITLE
Add `GridView::keepColumnAttributesInEmptyCell()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.2.1 under development
 
+- New #359: Add `GridView::keepColumnAttributesInEmptyCell()` to keep column body cell attributes on empty cells (@vjik)
 - Enh #358: Make dependency container in `GridView` constructor optional (@vjik)
 
 ## 1.2.0 September 02, 2026

--- a/docs/en/guide/gridview.md
+++ b/docs/en/guide/gridview.md
@@ -708,6 +708,7 @@ When a cell has no content, GridView renders an empty cell. You can customize it
 |--------|-------------|
 | `emptyCell(string $content, ?array $attributes = null)` | Set empty cell HTML content and optionally its attributes. Default content: `&nbsp;` |
 | `emptyCellAttributes(array $attributes)` | Set HTML attributes for empty cells |
+| `keepColumnAttributesInEmptyCell(bool $enabled = true)` | Keep the attributes set by the column (grid-level `bodyCellAttributes()` and column-level `bodyAttributes`/`bodyClass`) on empty cells. Disabled by default |
 
 ```php
 echo GridView::widget()
@@ -715,6 +716,11 @@ echo GridView::widget()
     ->emptyCell('-', ['class' => 'empty'])
     ->columns(/* ... */);
 ```
+
+By default an empty cell uses `emptyCellAttributes()` only. Enable `keepColumnAttributesInEmptyCell()` to preserve
+the column's own body cell attributes (for example, responsive CSS classes) on empty cells. In that case the empty
+cell attributes are layered on top of the column's attributes: CSS classes are merged, other attributes from
+`emptyCellAttributes()` take precedence on conflict.
 
 ## No Results Customization
 

--- a/src/GridView/GridView.php
+++ b/src/GridView/GridView.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Yiisoft\Yii\DataView\GridView;
 
-use BackedEnum;
 use Closure;
 use Psr\Container\ContainerInterface;
 use Stringable;
@@ -37,9 +36,7 @@ use function array_merge;
 use function call_user_func_array;
 use function count;
 use function in_array;
-use function is_array;
 use function is_callable;
-use function is_string;
 
 use const ARRAY_FILTER_USE_KEY;
 
@@ -980,7 +977,7 @@ final class GridView extends BaseListView
                 $tags[] = $cell->isEmptyContent()
                     ? Html::td(
                         $this->emptyCell,
-                        $this->prepareEmptyBodyCellAttributes($cell->getAttributes(), $context)
+                        $this->prepareEmptyBodyCellAttributes($cell->getAttributes(), $context),
                     )->encode(false)
                     : Html::td(attributes: $this->prepareBodyCellAttributes($cell->getAttributes(), $context))
                         ->content(...$cell->getContent())

--- a/src/GridView/GridView.php
+++ b/src/GridView/GridView.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Yiisoft\Yii\DataView\GridView;
 
+use BackedEnum;
 use Closure;
 use Psr\Container\ContainerInterface;
 use Stringable;
@@ -31,10 +32,14 @@ use Yiisoft\Yii\DataView\GridView\Column\SortableColumnRendererInterface;
 use Yiisoft\Yii\DataView\Url\UrlParametersFactory;
 use Yiisoft\Yii\DataView\Url\UrlParameterType;
 
+use function array_key_exists;
+use function array_merge;
 use function call_user_func_array;
 use function count;
 use function in_array;
+use function is_array;
 use function is_callable;
+use function is_string;
 
 use const ARRAY_FILTER_USE_KEY;
 
@@ -87,6 +92,11 @@ final class GridView extends BaseListView
      * @var array HTML attributes for empty cells
      */
     private array $emptyCellAttributes = [];
+
+    /**
+     * @var bool Whether an empty body cell keeps the HTML attributes set by its column.
+     */
+    private bool $keepColumnAttributesInEmptyCell = false;
 
     /**
      * @var bool Whether the footer section is enabled.
@@ -463,6 +473,25 @@ final class GridView extends BaseListView
     {
         $new = clone $this;
         $new->emptyCellAttributes = $attributes;
+        return $new;
+    }
+
+    /**
+     * Returns a new instance with a flag defining whether an empty body cell keeps the HTML attributes set by its
+     * column (grid-level {@see bodyCellAttributes()} and column-level `bodyAttributes`/`bodyClass`).
+     *
+     * When enabled, {@see emptyCellAttributes()} are layered on top of the column's attributes: CSS classes are
+     * merged, other attributes from {@see emptyCellAttributes()} take precedence on conflict. When disabled
+     * (default), an empty cell uses {@see emptyCellAttributes()} only.
+     *
+     * @param bool $enabled Whether an empty body cell keeps the attributes set by its column.
+     *
+     * @return self New instance with the flag applied.
+     */
+    public function keepColumnAttributesInEmptyCell(bool $enabled = true): self
+    {
+        $new = clone $this;
+        $new->keepColumnAttributesInEmptyCell = $enabled;
         return $new;
     }
 
@@ -949,7 +978,10 @@ final class GridView extends BaseListView
                 $context = new DataContext($preparedDataReader, $column, $value, $key, $index);
                 $cell = $renderers[$i]->renderBody($column, new Cell($this->bodyCellAttributes), $context);
                 $tags[] = $cell->isEmptyContent()
-                    ? Html::td($this->emptyCell, $this->emptyCellAttributes)->encode(false)
+                    ? Html::td(
+                        $this->emptyCell,
+                        $this->prepareEmptyBodyCellAttributes($cell->getAttributes(), $context)
+                    )->encode(false)
                     : Html::td(attributes: $this->prepareBodyCellAttributes($cell->getAttributes(), $context))
                         ->content(...$cell->getContent())
                         ->encode($cell->shouldEncode())
@@ -1109,6 +1141,33 @@ final class GridView extends BaseListView
         }
 
         return $attributes;
+    }
+
+    /**
+     * Prepares the attributes for an empty body cell.
+     *
+     * @param array $attributes The column's body cell attributes.
+     * @param DataContext $context The data context.
+     *
+     * @return array The prepared attributes.
+     */
+    private function prepareEmptyBodyCellAttributes(array $attributes, DataContext $context): array
+    {
+        if (!$this->keepColumnAttributesInEmptyCell) {
+            return $this->emptyCellAttributes;
+        }
+
+        $attributes = $this->prepareBodyCellAttributes($attributes, $context);
+
+        $emptyCellAttributes = $this->emptyCellAttributes;
+        if (array_key_exists('class', $emptyCellAttributes)) {
+            $class = $emptyCellAttributes['class'];
+            unset($emptyCellAttributes['class']);
+            /** @psalm-suppress MixedArgument We assume that class is valid value. */
+            Html::addCssClass($attributes, $class);
+        }
+
+        return array_merge($attributes, $emptyCellAttributes);
     }
 
     /**

--- a/tests/GridView/GridViewTest.php
+++ b/tests/GridView/GridViewTest.php
@@ -418,6 +418,64 @@ final class GridViewTest extends TestCase
         );
     }
 
+    #[TestWith([false, '<td class="empty-cell">N/A</td>'])]
+    #[TestWith([true, '<td data-label="Name" class="d-none d-md-table-cell empty-cell">N/A</td>'])]
+    public function testKeepColumnAttributesInEmptyCell(bool $keep, string $expectedCell): void
+    {
+        $gridView = $this->createGridView([
+            ['id' => 1, 'name' => null],
+        ])
+            ->emptyCell('N/A', ['class' => 'empty-cell'])
+            ->columns(
+                new DataColumn(property: 'id'),
+                new DataColumn(
+                    property: 'name',
+                    bodyAttributes: ['data-label' => 'Name'],
+                    bodyClass: 'd-none d-md-table-cell',
+                ),
+            );
+
+        if ($keep) {
+            $gridView = $gridView->keepColumnAttributesInEmptyCell();
+        }
+
+        $this->assertStringContainsString($expectedCell, $gridView->render());
+    }
+
+    public function testKeepColumnAttributesInEmptyCellWithEmptyCellAttributesTakingPrecedence(): void
+    {
+        $html = $this->createGridView([
+            ['id' => 1, 'name' => null],
+        ])
+            ->emptyCell('N/A')
+            ->emptyCellAttributes(['data-label' => 'Empty'])
+            ->keepColumnAttributesInEmptyCell()
+            ->columns(
+                new DataColumn(property: 'id'),
+                new DataColumn(property: 'name', bodyAttributes: ['data-label' => 'Name']),
+            )
+            ->render();
+
+        $this->assertStringContainsString('<td data-label="Empty">N/A</td>', $html);
+    }
+
+    public function testKeepColumnAttributesInEmptyCellDisabled(): void
+    {
+        $html = $this->createGridView([
+            ['id' => 1, 'name' => null],
+        ])
+            ->emptyCell('N/A', ['class' => 'empty-cell'])
+            ->keepColumnAttributesInEmptyCell()
+            ->keepColumnAttributesInEmptyCell(false)
+            ->columns(
+                new DataColumn(property: 'id'),
+                new DataColumn(property: 'name', bodyClass: 'd-none d-md-table-cell'),
+            )
+            ->render();
+
+        $this->assertStringContainsString('<td class="empty-cell">N/A</td>', $html);
+    }
+
     public function testFooterRowAttributes(): void
     {
         $html = $this->createGridView()
@@ -2799,6 +2857,7 @@ final class GridViewTest extends TestCase
         $this->assertNotSame($gridView, $gridView->columnGrouping());
         $this->assertNotSame($gridView, $gridView->emptyCell('test'));
         $this->assertNotSame($gridView, $gridView->emptyCellAttributes([]));
+        $this->assertNotSame($gridView, $gridView->keepColumnAttributesInEmptyCell());
         $this->assertNotSame($gridView, $gridView->enableFooter());
         $this->assertNotSame($gridView, $gridView->footerRowAttributes([]));
         $this->assertNotSame($gridView, $gridView->enableHeader());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
