### PR TITLE
Render disabled `KeysetPagination` items as `span` instead of `a` w/o `href`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 - New #362: Add `GridView::captionAttributes()` method and `$attributes` parameter to `GridView::caption()` to set
   HTML attributes for the `caption` tag (@vjik)
 - Enh #358: Make dependency container in `GridView` constructor optional (@vjik)
+- Bug #363: Render disabled `KeysetPagination` items ("previous" on the first page, "next" on the last page) as
+  `span` elements instead of `a` elements without an `href` (@vjik)
 
 ## 1.2.0 September 02, 2026
 

--- a/docs/en/guide/pagination.md
+++ b/docs/en/guide/pagination.md
@@ -141,11 +141,13 @@ Labels:
 - `labelPrevious(string|Stringable $label)` - Label for the "previous page" link. Default: `'⟨'`.
 - `labelNext(string|Stringable $label)` - Label for the "next page" link. Default: `'⟩'`.
 
+A disabled item ("previous" on the first page, "next" on the last page) has no URL and is rendered as a `<span>` instead
+of an `<a>` element.
+
 CSS classes for disabled state:
 
-- `disabledItemClass(?string $class)` - CSS class added to the item tag of disabled links (previous on the first page,
-  next on the last page).
-- `disabledLinkClass(?string $class)` - CSS class added to the `<a>` tag of disabled links.
+- `disabledItemClass(?string $class)` - CSS class added to the item tag of disabled items.
+- `disabledLinkClass(?string $class)` - CSS class added to the `<span>` tag of disabled items.
 
 Link attributes:
 

--- a/docs/en/guide/pagination.md
+++ b/docs/en/guide/pagination.md
@@ -153,7 +153,7 @@ Link attributes:
 
 - `linkAttributes(array $attributes)` - Set HTML attributes for each link, or the `<span>` that replaces it when
   disabled (replaces existing attributes).
-- `linkClass(BackedEnum|string|null ...$class)` - Set CSS classes on each link (or the disabled `<span>`), replaces
+- `linkClass(BackedEnum|string|null ...$class)` - Set CSS classes on each link (or the disabled `<span>`), replacing
   existing classes.
 - `addLinkClass(BackedEnum|string|null ...$class)` - Add CSS classes to each link (or the disabled `<span>`) without
   removing existing ones.

--- a/docs/en/guide/pagination.md
+++ b/docs/en/guide/pagination.md
@@ -151,9 +151,12 @@ CSS classes for disabled state:
 
 Link attributes:
 
-- `linkAttributes(array $attributes)` - Set HTML attributes for all `<a>` link elements (replaces existing attributes).
-- `linkClass(BackedEnum|string|null ...$class)` - Set CSS classes on link elements (replaces existing classes).
-- `addLinkClass(BackedEnum|string|null ...$class)` - Add CSS classes to link elements without removing existing ones.
+- `linkAttributes(array $attributes)` - Set HTML attributes for each link, or the `<span>` that replaces it when
+  disabled (replaces existing attributes).
+- `linkClass(BackedEnum|string|null ...$class)` - Set CSS classes on each link (or the disabled `<span>`), replaces
+  existing classes.
+- `addLinkClass(BackedEnum|string|null ...$class)` - Add CSS classes to each link (or the disabled `<span>`) without
+  removing existing ones.
 
 HTML structure:
 
@@ -161,7 +164,7 @@ HTML structure:
 - `containerAttributes(array $attributes)` - HTML attributes for the container tag.
 - `listTag(?string $tag)` - Tag wrapping all pagination items. Default: `null`. Common value: `'ul'`.
 - `listAttributes(array $attributes)` - HTML attributes for the list tag.
-- `itemTag(?string $tag)` - Tag wrapping each link. Default: `null`. Common value: `'li'`.
+- `itemTag(?string $tag)` - Tag wrapping each link (or the disabled `<span>`). Default: `null`. Common value: `'li'`.
 - `itemAttributes(array $attributes)` - HTML attributes for item tags.
 
 ## Page sizes

--- a/src/Pagination/KeysetPagination.php
+++ b/src/Pagination/KeysetPagination.php
@@ -246,7 +246,7 @@ final class KeysetPagination extends Widget implements PaginationWidgetInterface
     }
 
     /**
-     * Adds one or more CSS classes to the existing link classes are applied to the "previous"/"next" control.
+     * Adds one or more CSS classes to the existing classes of the "previous"/"next" control.
      *
      * Multiple classes can be added by passing them as separate arguments. `null` values are filtered out
      * automatically.

--- a/src/Pagination/KeysetPagination.php
+++ b/src/Pagination/KeysetPagination.php
@@ -163,7 +163,7 @@ final class KeysetPagination extends Widget implements PaginationWidgetInterface
     }
 
     /**
-     * Sets the item tag name.
+     * Sets the item tag name that wraps the "previous"/"next" control.
      *
      * @param string|null $tag The tag name for the item elements.
      * Common values: 'li', 'div'. Use `null` to omit item containers.
@@ -214,7 +214,7 @@ final class KeysetPagination extends Widget implements PaginationWidgetInterface
     /**
      * Sets the link attributes.
      *
-     * @param array $attributes HTML attributes for the link elements.
+     * @param array $attributes HTML attributes for the "previous"/"next" control.
      *
      * @return self New instance with the specified link attributes.
      */
@@ -227,6 +227,9 @@ final class KeysetPagination extends Widget implements PaginationWidgetInterface
 
     /**
      * Set new link classes.
+     *
+     * The classes are applied to the "previous"/"next" control — the `a` element, or the `span` element that
+     * replaces it when the control is disabled.
      *
      * Multiple classes can be set by passing them as separate arguments. `null` values are filtered out
      * automatically.
@@ -243,7 +246,7 @@ final class KeysetPagination extends Widget implements PaginationWidgetInterface
     }
 
     /**
-     * Adds one or more CSS classes to the existing link classes.
+     * Adds one or more CSS classes to the existing link classes are applied to the "previous"/"next" control.
      *
      * Multiple classes can be added by passing them as separate arguments. `null` values are filtered out
      * automatically.
@@ -259,9 +262,11 @@ final class KeysetPagination extends Widget implements PaginationWidgetInterface
     }
 
     /**
-     * Sets the CSS class for disabled link elements.
+     * Sets the CSS class for a disabled "previous"/"next" control.
      *
-     * @param string|null $class The CSS class for disabled links.
+     * A disabled control ("previous" on the first page, "next" on the last page) is rendered as a `span` element.
+     *
+     * @param string|null $class The CSS class for the `span` element of a disabled control.
      *
      * @return self New instance with the specified disabled link class.
      */

--- a/src/Pagination/KeysetPagination.php
+++ b/src/Pagination/KeysetPagination.php
@@ -328,13 +328,11 @@ final class KeysetPagination extends Widget implements PaginationWidgetInterface
         $result .= $this->renderItem(
             $this->labelPrevious,
             $previousToken === null ? null : $context->createUrl($previousToken),
-            $previousToken === null,
         )
             . "\n"
             . $this->renderItem(
                 $this->labelNext,
                 $nextToken === null ? null : $context->createUrl($nextToken),
-                $nextToken === null,
             );
 
         if ($this->listTag !== null) {
@@ -351,28 +349,32 @@ final class KeysetPagination extends Widget implements PaginationWidgetInterface
      * Renders a single pagination item (previous or next).
      *
      * @param string|Stringable $label The item label.
-     * @param string|null $url The item URL, or null if disabled.
-     * @param bool $isDisabled Whether the item should be rendered as disabled.
+     * @param string|null $url The item URL, or `null` when the item is disabled. A disabled item is rendered as
+     * a `span` instead of an `a` element.
      *
      * @return Stringable The rendered HTML for the pagination item.
      */
-    private function renderItem(string|Stringable $label, ?string $url, bool $isDisabled): Stringable
+    private function renderItem(string|Stringable $label, ?string $url): Stringable
     {
+        $isDisabled = $url === null;
+
         $linkAttributes = $this->linkAttributes;
         if ($isDisabled) {
             Html::addCssClass($linkAttributes, $this->disabledLinkClass);
         }
-        $link = Html::a($label, $url, $linkAttributes);
+        $element = $isDisabled
+            ? Html::span($label, $linkAttributes)
+            : Html::a($label, $url, $linkAttributes);
 
         if ($this->itemTag === null) {
-            return $link;
+            return $element;
         }
 
         $attributes = $this->itemAttributes;
         if ($isDisabled) {
             Html::addCssClass($attributes, $this->disabledItemClass);
         }
-        return Html::tag($this->itemTag, $link, $attributes);
+        return Html::tag($this->itemTag, $element, $attributes);
     }
 
     /**

--- a/tests/GridView/GridViewTest.php
+++ b/tests/GridView/GridViewTest.php
@@ -2191,7 +2191,7 @@ final class GridViewTest extends TestCase
         $this->assertStringContainsString(
             <<<HTML
             <nav>
-            <a>⟨</a>
+            <span>⟨</span>
             <a href="/route?page=10">⟩</a>
             </nav>
             HTML,

--- a/tests/Pagination/KeysetPaginationTest.php
+++ b/tests/Pagination/KeysetPaginationTest.php
@@ -24,7 +24,7 @@ final class KeysetPaginationTest extends TestCase
         $this->assertSame(
             <<<HTML
             <nav>
-            <a>⟨</a>
+            <span>⟨</span>
             <a href="/next/id1">⟩</a>
             </nav>
             HTML,
@@ -45,8 +45,8 @@ final class KeysetPaginationTest extends TestCase
     #[TestWith([
         <<<HTML
         <nav>
-        <a>⟨</a>
-        <a>⟩</a>
+        <span>⟨</span>
+        <span>⟩</span>
         </nav>
         HTML,
         true,
@@ -72,7 +72,7 @@ final class KeysetPaginationTest extends TestCase
         $this->assertSame(
             <<<HTML
             <main>
-            <a>⟨</a>
+            <span>⟨</span>
             <a href="/next/id1">⟩</a>
             </main>
             HTML,
@@ -89,7 +89,7 @@ final class KeysetPaginationTest extends TestCase
 
         $this->assertSame(
             <<<HTML
-            <a>⟨</a>
+            <span>⟨</span>
             <a href="/next/id1">⟩</a>
             HTML,
             $html,
@@ -115,7 +115,7 @@ final class KeysetPaginationTest extends TestCase
         $this->assertSame(
             <<<HTML
             <nav class="pagination-nav" id="main-nav">
-            <a>⟨</a>
+            <span>⟨</span>
             <a href="/next/id1">⟩</a>
             </nav>
             HTML,
@@ -134,7 +134,7 @@ final class KeysetPaginationTest extends TestCase
             <<<HTML
             <nav>
             <ul>
-            <a>⟨</a>
+            <span>⟨</span>
             <a href="/next/id1">⟩</a>
             </ul>
             </nav>
@@ -153,7 +153,7 @@ final class KeysetPaginationTest extends TestCase
         $this->assertSame(
             <<<HTML
             <nav>
-            <a>⟨</a>
+            <span>⟨</span>
             <a href="/next/id1">⟩</a>
             </nav>
             HTML,
@@ -182,7 +182,7 @@ final class KeysetPaginationTest extends TestCase
             <<<HTML
             <nav>
             <ul class="pagination-list" data-role="navigation">
-            <a>⟨</a>
+            <span>⟨</span>
             <a href="/next/id1">⟩</a>
             </ul>
             </nav>
@@ -201,7 +201,7 @@ final class KeysetPaginationTest extends TestCase
         $this->assertSame(
             <<<HTML
             <nav>
-            <li><a>⟨</a></li>
+            <li><span>⟨</span></li>
             <li><a href="/next/id1">⟩</a></li>
             </nav>
             HTML,
@@ -219,7 +219,7 @@ final class KeysetPaginationTest extends TestCase
         $this->assertSame(
             <<<HTML
             <nav>
-            <a>⟨</a>
+            <span>⟨</span>
             <a href="/next/id1">⟩</a>
             </nav>
             HTML,
@@ -247,7 +247,7 @@ final class KeysetPaginationTest extends TestCase
         $this->assertSame(
             <<<HTML
             <nav>
-            <li class="pagination-item" data-type="nav-button"><a>⟨</a></li>
+            <li class="pagination-item" data-type="nav-button"><span>⟨</span></li>
             <li class="pagination-item" data-type="nav-button"><a href="/next/id1">⟩</a></li>
             </nav>
             HTML,
@@ -266,7 +266,7 @@ final class KeysetPaginationTest extends TestCase
         $this->assertSame(
             <<<HTML
             <nav>
-            <li class="disabled"><a>⟨</a></li>
+            <li class="disabled"><span>⟨</span></li>
             <li><a href="/next/id1">⟩</a></li>
             </nav>
             HTML,
@@ -284,7 +284,7 @@ final class KeysetPaginationTest extends TestCase
         $this->assertSame(
             <<<HTML
             <nav>
-            <a class="pagination-link" data-action="navigate">⟨</a>
+            <span class="pagination-link" data-action="navigate">⟨</span>
             <a class="pagination-link" data-action="navigate" href="/next/id1">⟩</a>
             </nav>
             HTML,
@@ -302,7 +302,7 @@ final class KeysetPaginationTest extends TestCase
         $this->assertSame(
             <<<HTML
             <nav>
-            <a class="btn btn-primary">⟨</a>
+            <span class="btn btn-primary">⟨</span>
             <a class="btn btn-primary" href="/next/id1">⟩</a>
             </nav>
             HTML,
@@ -321,7 +321,7 @@ final class KeysetPaginationTest extends TestCase
         $this->assertSame(
             <<<HTML
             <nav>
-            <a class="btn btn-primary active">⟨</a>
+            <span class="btn btn-primary active">⟨</span>
             <a class="btn btn-primary active" href="/next/id1">⟩</a>
             </nav>
             HTML,
@@ -340,7 +340,7 @@ final class KeysetPaginationTest extends TestCase
         $this->assertSame(
             <<<HTML
             <nav>
-            <a class="btn btn-primary disabled">⟨</a>
+            <span class="btn btn-primary disabled">⟨</span>
             <a class="btn btn-primary" href="/next/id1">⟩</a>
             </nav>
             HTML,
@@ -358,7 +358,7 @@ final class KeysetPaginationTest extends TestCase
         $this->assertSame(
             <<<HTML
             <nav>
-            <a>Prev</a>
+            <span>Prev</span>
             <a href="/next/id1">⟩</a>
             </nav>
             HTML,
@@ -376,7 +376,7 @@ final class KeysetPaginationTest extends TestCase
         $this->assertSame(
             <<<HTML
             <nav>
-            <a>⟨</a>
+            <span>⟨</span>
             <a href="/next/id1">Next</a>
             </nav>
             HTML,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
