### PR TITLE
Render disabled `OffsetPagination` controls as `span` instead of `a`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - New #362: Add `GridView::captionAttributes()` method and `$attributes` parameter to `GridView::caption()` to set
   HTML attributes for the `caption` tag (@vjik)
 - Enh #358: Make dependency container in `GridView` constructor optional (@vjik)
-- Bug #363: Render disabled `KeysetPagination` items ("previous" on the first page, "next" on the last page) as
+- Bug #363: Render disabled `KeysetPagination` controls ("previous" on the first page, "next" on the last page) as
   `span` elements instead of `a` elements without an `href` (@vjik)
 - Bug #364: Render disabled `OffsetPagination` controls ("first"/"previous" on the first page, "next"/"last" on the
   last page) as `span` elements instead of clickable `a` elements (@vjik)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 - Enh #358: Make dependency container in `GridView` constructor optional (@vjik)
 - Bug #363: Render disabled `KeysetPagination` items ("previous" on the first page, "next" on the last page) as
   `span` elements instead of `a` elements without an `href` (@vjik)
+- Bug #364: Render disabled `OffsetPagination` controls ("first"/"previous" on the first page, "next"/"last" on the
+  last page) as `span` elements instead of clickable `a` elements (@vjik)
 
 ## 1.2.0 September 02, 2026
 

--- a/docs/en/guide/pagination.md
+++ b/docs/en/guide/pagination.md
@@ -51,20 +51,25 @@ Navigation:
 - `maxNavLinkCount(int $value)` - Maximum number of page number links to show. Default: `10`. When there are more pages
   than this limit, a sliding window of links is shown around the current page.
 
+The first/previous/next/last controls have no URL when they are disabled (first/previous on the first page, next/last
+on the last page) and are then rendered as a `<span>` instead of an `<a>` element.
+
 CSS classes for current/disabled states:
 
 - `currentItemClass(?string $class)` - CSS class added to the item tag (`itemTag`) of the current page.
-- `disabledItemClass(?string $class)` - CSS class added to the item tag of disabled links (first/previous on page 1,
-  next/last on the last page).
+- `disabledItemClass(?string $class)` - CSS class added to the item tag (`itemTag`) of a disabled control.
 - `currentLinkClass(?string $class)` - CSS class added to the `<a>` tag of the current page link.
-- `disabledLinkClass(?string $class)` - CSS class added to the `<a>` tag of disabled links.
+- `disabledLinkClass(?string $class)` - CSS class added to the `<span>` tag of a disabled control.
 
 Link attributes:
 
-- `linkAttributes(array $attributes)` - Set HTML attributes for all `<a>` link elements (replaces existing attributes).
+- `linkAttributes(array $attributes)` - Set HTML attributes for each link, or for the `<span>` that replaces it on a
+  disabled control (replaces existing attributes).
 - `addLinkAttributes(array $attributes)` - Merge additional HTML attributes into existing link attributes.
-- `linkClass(BackedEnum|string|null ...$class)` - Set CSS classes on link elements (replaces existing classes).
-- `addLinkClass(BackedEnum|string|null ...$class)` - Add CSS classes to link elements without removing existing ones.
+- `linkClass(BackedEnum|string|null ...$class)` - Set CSS classes on each link (or the disabled `<span>`), replacing
+  existing classes.
+- `addLinkClass(BackedEnum|string|null ...$class)` - Add CSS classes to each link (or the disabled `<span>`) without
+  removing existing ones.
 
 HTML structure:
 
@@ -74,7 +79,8 @@ The pagination markup is structured as "container > list > item > link". Each le
 - `containerAttributes(array $attributes)` - HTML attributes for the container tag.
 - `listTag(?string $tag)` - Tag wrapping all pagination items. Default: `null` (no list wrapper). Common value: `'ul'`.
 - `listAttributes(array $attributes)` - HTML attributes for the list tag.
-- `itemTag(?string $tag)` - Tag wrapping each individual link. Default: `null` (no item wrapper). Common value: `'li'`.
+- `itemTag(?string $tag)` - Tag wrapping each individual link (or the `<span>` of a disabled control). Default: `null`
+  (no item wrapper). Common value: `'li'`.
 - `itemAttributes(array $attributes)` - HTML attributes for item tags.
 
 Example with Bootstrap 5 styling:
@@ -141,13 +147,13 @@ Labels:
 - `labelPrevious(string|Stringable $label)` - Label for the "previous page" link. Default: `'⟨'`.
 - `labelNext(string|Stringable $label)` - Label for the "next page" link. Default: `'⟩'`.
 
-A disabled item ("previous" on the first page, "next" on the last page) has no URL and is rendered as a `<span>` instead
-of an `<a>` element.
+A disabled control ("previous" on the first page, "next" on the last page) has no URL and is rendered as a `<span>`
+instead of an `<a>` element.
 
 CSS classes for disabled state:
 
-- `disabledItemClass(?string $class)` - CSS class added to the item tag of disabled items.
-- `disabledLinkClass(?string $class)` - CSS class added to the `<span>` tag of disabled items.
+- `disabledItemClass(?string $class)` - CSS class added to the item tag (`itemTag`) of a disabled control.
+- `disabledLinkClass(?string $class)` - CSS class added to the `<span>` tag of a disabled control.
 
 Link attributes:
 

--- a/src/Pagination/OffsetPagination.php
+++ b/src/Pagination/OffsetPagination.php
@@ -187,6 +187,9 @@ final class OffsetPagination extends Widget implements PaginationWidgetInterface
     /**
      * Set new link classes.
      *
+     * The classes are applied to each link (the `a` element, or the `span` element that replaces it when
+     * a first/previous/next/last control is disabled).
+     *
      * Multiple classes can be set by passing them as separate arguments. `null` values are filtered out
      * automatically.
      *
@@ -202,7 +205,8 @@ final class OffsetPagination extends Widget implements PaginationWidgetInterface
     }
 
     /**
-     * Adds one or more CSS classes to the existing link classes.
+     * Adds one or more CSS classes to the existing classes of each link (the `a` element, or the `span` element
+     * that replaces it when a first/previous/next/last control is disabled).
      *
      * Multiple classes can be added by passing them as separate arguments. `null` values are filtered out
      * automatically.
@@ -224,6 +228,11 @@ final class OffsetPagination extends Widget implements PaginationWidgetInterface
         return $new;
     }
 
+    /**
+     * Sets the CSS class for a disabled control.
+     *
+     * @param string|null $class The CSS class for the `span` element of a disabled control.
+     */
     public function disabledLinkClass(?string $class): self
     {
         $new = clone $this;
@@ -315,18 +324,18 @@ final class OffsetPagination extends Widget implements PaginationWidgetInterface
         if ($this->labelFirst !== null) {
             $items[] = $this->renderItem(
                 label: $this->labelFirst,
-                url: $this->createUrl(PageToken::next('1')),
+                url: $currentPage === 1 ? null : $this->createUrl(PageToken::next('1')),
                 isCurrent: false,
-                isDisabled: $currentPage === 1,
             );
         }
 
         if ($this->labelPrevious !== null) {
             $items[] = $this->renderItem(
                 label: $this->labelPrevious,
-                url: $this->createUrl(PageToken::next((string) max($currentPage - 1, 1))),
+                url: $currentPage === 1
+                    ? null
+                    : $this->createUrl(PageToken::next((string) max($currentPage - 1, 1))),
                 isCurrent: false,
-                isDisabled: $currentPage === 1,
             );
         }
 
@@ -336,33 +345,38 @@ final class OffsetPagination extends Widget implements PaginationWidgetInterface
                 label: (string) $page,
                 url: $this->createUrl(PageToken::next((string) $page)),
                 isCurrent: $page === $currentPage,
-                isDisabled: false,
             );
         } while (++$page <= $endPage);
 
         if ($this->labelNext !== null) {
             $items[] = $this->renderItem(
                 label: $this->labelNext,
-                url: $this->createUrl(PageToken::next((string) min($currentPage + 1, $totalPages))),
+                url: $currentPage === $totalPages
+                    ? null
+                    : $this->createUrl(PageToken::next((string) min($currentPage + 1, $totalPages))),
                 isCurrent: false,
-                isDisabled: $currentPage === $totalPages,
             );
         }
 
         if ($this->labelLast !== null) {
             $items[] = $this->renderItem(
                 label: $this->labelLast,
-                url: $this->createUrl(PageToken::next((string) $totalPages)),
+                url: $currentPage === $totalPages ? null : $this->createUrl(PageToken::next((string) $totalPages)),
                 isCurrent: false,
-                isDisabled: $currentPage === $totalPages,
             );
         }
 
         return $items;
     }
 
-    private function renderItem(string|Stringable $label, string $url, bool $isCurrent, bool $isDisabled): Stringable
+    /**
+     * @param string|null $url The item URL, or `null` when the control is disabled. A disabled control is rendered as
+     * a `span` instead of an `a` element.
+     */
+    private function renderItem(string|Stringable $label, ?string $url, bool $isCurrent): Stringable
     {
+        $isDisabled = $url === null;
+
         $linkAttributes = $this->linkAttributes;
         if ($isDisabled) {
             Html::addCssClass($linkAttributes, $this->disabledLinkClass);
@@ -370,10 +384,12 @@ final class OffsetPagination extends Widget implements PaginationWidgetInterface
         if ($isCurrent) {
             Html::addCssClass($linkAttributes, $this->currentLinkClass);
         }
-        $link = Html::a($label, $url, $linkAttributes);
+        $element = $isDisabled
+            ? Html::span($label, $linkAttributes)
+            : Html::a($label, $url, $linkAttributes);
 
         if ($this->itemTag === null) {
-            return $link;
+            return $element;
         }
 
         $attributes = $this->itemAttributes;
@@ -383,7 +399,7 @@ final class OffsetPagination extends Widget implements PaginationWidgetInterface
         if ($isCurrent) {
             Html::addCssClass($attributes, $this->currentItemClass);
         }
-        return Html::tag($this->itemTag, $link, $attributes);
+        return Html::tag($this->itemTag, $element, $attributes);
     }
 
     /**

--- a/tests/GridView/GridViewTest.php
+++ b/tests/GridView/GridViewTest.php
@@ -1384,8 +1384,8 @@ final class GridViewTest extends TestCase
         $this->assertStringContainsString(
             <<<HTML
             <nav>
-            <a href="/route?">⟪</a>
-            <a href="/route?">⟨</a>
+            <span>⟪</span>
+            <span>⟨</span>
             <a href="/route?">1</a>
             <a href="/route?p=2">2</a>
             <a href="/route?p=2">⟩</a>

--- a/tests/Pagination/OffsetPaginationTest.php
+++ b/tests/Pagination/OffsetPaginationTest.php
@@ -25,8 +25,8 @@ final class OffsetPaginationTest extends TestCase
         $this->assertSame(
             <<<HTML
             <nav>
-            <a href="/">⟪</a>
-            <a href="/">⟨</a>
+            <span>⟪</span>
+            <span>⟨</span>
             <a href="/">1</a>
             <a href="/page/2">2</a>
             <a href="/page/3">3</a>
@@ -66,11 +66,11 @@ final class OffsetPaginationTest extends TestCase
     #[TestWith([
         <<<HTML
         <nav>
-        <a href="/">⟪</a>
-        <a href="/">⟨</a>
+        <span>⟪</span>
+        <span>⟨</span>
         <a href="/">1</a>
-        <a href="/">⟩</a>
-        <a href="/">⟫</a>
+        <span>⟩</span>
+        <span>⟫</span>
         </nav>
         HTML,
         true,
@@ -96,8 +96,8 @@ final class OffsetPaginationTest extends TestCase
         $this->assertSame(
             <<<HTML
             <main>
-            <a href="/">⟪</a>
-            <a href="/">⟨</a>
+            <span>⟪</span>
+            <span>⟨</span>
             <a href="/">1</a>
             <a href="/page/2">2</a>
             <a href="/page/2">⟩</a>
@@ -117,8 +117,8 @@ final class OffsetPaginationTest extends TestCase
 
         $this->assertSame(
             <<<HTML
-            <a href="/">⟪</a>
-            <a href="/">⟨</a>
+            <span>⟪</span>
+            <span>⟨</span>
             <a href="/">1</a>
             <a href="/page/2">2</a>
             <a href="/page/2">⟩</a>
@@ -147,8 +147,8 @@ final class OffsetPaginationTest extends TestCase
         $this->assertSame(
             <<<HTML
             <nav class="pagination-nav" id="main-nav">
-            <a href="/">⟪</a>
-            <a href="/">⟨</a>
+            <span>⟪</span>
+            <span>⟨</span>
             <a href="/">1</a>
             <a href="/page/2">2</a>
             <a href="/page/2">⟩</a>
@@ -170,8 +170,8 @@ final class OffsetPaginationTest extends TestCase
             <<<HTML
             <nav>
             <ul>
-            <a href="/">⟪</a>
-            <a href="/">⟨</a>
+            <span>⟪</span>
+            <span>⟨</span>
             <a href="/">1</a>
             <a href="/page/2">2</a>
             <a href="/page/2">⟩</a>
@@ -193,8 +193,8 @@ final class OffsetPaginationTest extends TestCase
         $this->assertSame(
             <<<HTML
             <nav>
-            <a href="/">⟪</a>
-            <a href="/">⟨</a>
+            <span>⟪</span>
+            <span>⟨</span>
             <a href="/">1</a>
             <a href="/page/2">2</a>
             <a href="/page/2">⟩</a>
@@ -226,8 +226,8 @@ final class OffsetPaginationTest extends TestCase
             <<<HTML
             <nav>
             <ul class="pagination-list" data-role="navigation">
-            <a href="/">⟪</a>
-            <a href="/">⟨</a>
+            <span>⟪</span>
+            <span>⟨</span>
             <a href="/">1</a>
             <a href="/page/2">2</a>
             <a href="/page/2">⟩</a>
@@ -249,8 +249,8 @@ final class OffsetPaginationTest extends TestCase
         $this->assertSame(
             <<<HTML
             <nav>
-            <li><a href="/">⟪</a></li>
-            <li><a href="/">⟨</a></li>
+            <li><span>⟪</span></li>
+            <li><span>⟨</span></li>
             <li><a href="/">1</a></li>
             <li><a href="/page/2">2</a></li>
             <li><a href="/page/2">⟩</a></li>
@@ -271,8 +271,8 @@ final class OffsetPaginationTest extends TestCase
         $this->assertSame(
             <<<HTML
             <nav>
-            <a href="/">⟪</a>
-            <a href="/">⟨</a>
+            <span>⟪</span>
+            <span>⟨</span>
             <a href="/">1</a>
             <a href="/page/2">2</a>
             <a href="/page/2">⟩</a>
@@ -303,8 +303,8 @@ final class OffsetPaginationTest extends TestCase
         $this->assertSame(
             <<<HTML
             <nav>
-            <li class="pagination-item" data-type="nav-button"><a href="/">⟪</a></li>
-            <li class="pagination-item" data-type="nav-button"><a href="/">⟨</a></li>
+            <li class="pagination-item" data-type="nav-button"><span>⟪</span></li>
+            <li class="pagination-item" data-type="nav-button"><span>⟨</span></li>
             <li class="pagination-item" data-type="nav-button"><a href="/">1</a></li>
             <li class="pagination-item" data-type="nav-button"><a href="/page/2">2</a></li>
             <li class="pagination-item" data-type="nav-button"><a href="/page/2">⟩</a></li>
@@ -326,8 +326,8 @@ final class OffsetPaginationTest extends TestCase
         $this->assertSame(
             <<<HTML
             <nav>
-            <li><a href="/">⟪</a></li>
-            <li><a href="/">⟨</a></li>
+            <li><span>⟪</span></li>
+            <li><span>⟨</span></li>
             <li class="current"><a href="/">1</a></li>
             <li><a href="/page/2">2</a></li>
             <li><a href="/page/2">⟩</a></li>
@@ -349,8 +349,8 @@ final class OffsetPaginationTest extends TestCase
         $this->assertSame(
             <<<HTML
             <nav>
-            <li class="disabled"><a href="/">⟪</a></li>
-            <li class="disabled"><a href="/">⟨</a></li>
+            <li class="disabled"><span>⟪</span></li>
+            <li class="disabled"><span>⟨</span></li>
             <li><a href="/">1</a></li>
             <li><a href="/page/2">2</a></li>
             <li><a href="/page/3">3</a></li>
@@ -374,8 +374,8 @@ final class OffsetPaginationTest extends TestCase
         $this->assertSame(
             <<<HTML
             <nav>
-            <a class="pagination-link" data-action="navigate" href="/">⟪</a>
-            <a class="pagination-link" data-action="navigate" href="/">⟨</a>
+            <span class="pagination-link" data-action="navigate">⟪</span>
+            <span class="pagination-link" data-action="navigate">⟨</span>
             <a class="pagination-link" data-action="navigate" href="/">1</a>
             <a class="pagination-link" data-action="navigate" href="/page/2">2</a>
             <a class="pagination-link" data-action="navigate" href="/page/2">⟩</a>
@@ -397,8 +397,8 @@ final class OffsetPaginationTest extends TestCase
         $this->assertSame(
             <<<HTML
             <nav>
-            <a class="pagination-link" data-action="navigate" role="button" href="/">⟪</a>
-            <a class="pagination-link" data-action="navigate" role="button" href="/">⟨</a>
+            <span class="pagination-link" data-action="navigate" role="button">⟪</span>
+            <span class="pagination-link" data-action="navigate" role="button">⟨</span>
             <a class="pagination-link" data-action="navigate" role="button" href="/">1</a>
             <a class="pagination-link" data-action="navigate" role="button" href="/page/2">2</a>
             <a class="pagination-link" data-action="navigate" role="button" href="/page/2">⟩</a>
@@ -419,8 +419,8 @@ final class OffsetPaginationTest extends TestCase
         $this->assertSame(
             <<<HTML
             <nav>
-            <a class="btn btn-primary" href="/">⟪</a>
-            <a class="btn btn-primary" href="/">⟨</a>
+            <span class="btn btn-primary">⟪</span>
+            <span class="btn btn-primary">⟨</span>
             <a class="btn btn-primary" href="/">1</a>
             <a class="btn btn-primary" href="/page/2">2</a>
             <a class="btn btn-primary" href="/page/2">⟩</a>
@@ -442,8 +442,8 @@ final class OffsetPaginationTest extends TestCase
         $this->assertSame(
             <<<HTML
             <nav>
-            <a class="btn btn-primary active" href="/">⟪</a>
-            <a class="btn btn-primary active" href="/">⟨</a>
+            <span class="btn btn-primary active">⟪</span>
+            <span class="btn btn-primary active">⟨</span>
             <a class="btn btn-primary active" href="/">1</a>
             <a class="btn btn-primary active" href="/page/2">2</a>
             <a class="btn btn-primary active" href="/page/2">⟩</a>
@@ -465,8 +465,8 @@ final class OffsetPaginationTest extends TestCase
         $this->assertSame(
             <<<HTML
             <nav>
-            <a class="btn btn-primary" href="/">⟪</a>
-            <a class="btn btn-primary" href="/">⟨</a>
+            <span class="btn btn-primary">⟪</span>
+            <span class="btn btn-primary">⟨</span>
             <a class="btn btn-primary current" href="/">1</a>
             <a class="btn btn-primary" href="/page/2">2</a>
             <a class="btn btn-primary" href="/page/2">⟩</a>
@@ -488,8 +488,8 @@ final class OffsetPaginationTest extends TestCase
         $this->assertSame(
             <<<HTML
             <nav>
-            <a class="btn btn-primary disabled" href="/">⟪</a>
-            <a class="btn btn-primary disabled" href="/">⟨</a>
+            <span class="btn btn-primary disabled">⟪</span>
+            <span class="btn btn-primary disabled">⟨</span>
             <a class="btn btn-primary" href="/">1</a>
             <a class="btn btn-primary" href="/page/2">2</a>
             <a class="btn btn-primary" href="/page/3">3</a>
@@ -513,8 +513,8 @@ final class OffsetPaginationTest extends TestCase
         $this->assertSame(
             <<<HTML
             <nav>
-            <a href="/">⟪</a>
-            <a href="/">Prev</a>
+            <span>⟪</span>
+            <span>Prev</span>
             <a href="/">1</a>
             <a href="/page/2">2</a>
             <a href="/page/2">⟩</a>
@@ -535,8 +535,8 @@ final class OffsetPaginationTest extends TestCase
         $this->assertSame(
             <<<HTML
             <nav>
-            <a href="/">⟪</a>
-            <a href="/">⟨</a>
+            <span>⟪</span>
+            <span>⟨</span>
             <a href="/">1</a>
             <a href="/page/2">2</a>
             <a href="/page/2">Next</a>
@@ -557,8 +557,8 @@ final class OffsetPaginationTest extends TestCase
         $this->assertSame(
             <<<HTML
             <nav>
-            <a href="/">First</a>
-            <a href="/">⟨</a>
+            <span>First</span>
+            <span>⟨</span>
             <a href="/">1</a>
             <a href="/page/2">2</a>
             <a href="/page/2">⟩</a>
@@ -579,8 +579,8 @@ final class OffsetPaginationTest extends TestCase
         $this->assertSame(
             <<<HTML
             <nav>
-            <a href="/">⟪</a>
-            <a href="/">⟨</a>
+            <span>⟪</span>
+            <span>⟨</span>
             <a href="/">1</a>
             <a href="/page/2">2</a>
             <a href="/page/2">⟩</a>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
