### PR TITLE
Keep `GridView` and column header cell attributes when a column renders no header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
   `span` elements instead of `a` elements without an `href` (@vjik)
 - Bug #364: Render disabled `OffsetPagination` controls ("first"/"previous" on the first page, "next"/"last" on the
   last page) as `span` elements instead of clickable `a` elements (@vjik)
+- Bug #365: Keep `GridView` and column header cell attributes when a column renders no header (@vjik)
 
 ## 1.2.0 September 02, 2026
 

--- a/src/GridView/Column/CheckboxColumnRenderer.php
+++ b/src/GridView/Column/CheckboxColumnRenderer.php
@@ -23,19 +23,19 @@ final class CheckboxColumnRenderer implements ColumnRendererInterface
         return $cell->addAttributes($column->columnAttributes);
     }
 
-    public function renderHeader(ColumnInterface $column, Cell $cell, GlobalContext $context): ?Cell
+    public function renderHeader(ColumnInterface $column, Cell $cell, GlobalContext $context): Cell
     {
+        $cell = $cell->addAttributes($column->headerAttributes);
+
         $header = $column->header;
         if ($header === null) {
             if (!$column->multiple) {
-                return null;
+                return $cell;
             }
             $header = Html::checkbox('checkbox-selection-all', 1);
         }
 
-        return $cell
-            ->addAttributes($column->headerAttributes)
-            ->content($header);
+        return $cell->content($header);
     }
 
     public function renderBody(ColumnInterface $column, Cell $cell, DataContext $context): Cell

--- a/src/GridView/Column/ColumnRendererInterface.php
+++ b/src/GridView/Column/ColumnRendererInterface.php
@@ -73,12 +73,16 @@ interface ColumnRendererInterface
     /**
      * Configures the column header cell.
      *
+     * When the column has no header to show, return the cell with empty content: the grid renders a placeholder
+     * in it, keeping the cell attributes.
+     *
      * @param ColumnInterface $column The column definition to render.
      * @psalm-param TColumn $column
      * @param Cell $cell The header cell to configure.
      * @param GlobalContext $context Global grid rendering context.
      *
-     * @return Cell|null The configured header cell, or `null` if no header should be shown.
+     * @return Cell|null The configured header cell. `null` is treated the same way as a cell with empty content,
+     * and is supported for backward compatibility only: it will not be allowed in the next major version.
      */
     public function renderHeader(ColumnInterface $column, Cell $cell, GlobalContext $context): ?Cell;
 

--- a/src/GridView/Column/RadioColumnRenderer.php
+++ b/src/GridView/Column/RadioColumnRenderer.php
@@ -24,16 +24,16 @@ final class RadioColumnRenderer implements ColumnRendererInterface
         return $cell->addAttributes($column->columnAttributes);
     }
 
-    public function renderHeader(ColumnInterface $column, Cell $cell, GlobalContext $context): ?Cell
+    public function renderHeader(ColumnInterface $column, Cell $cell, GlobalContext $context): Cell
     {
+        $cell = $cell->addAttributes($column->headerAttributes);
+
         $header = $column->header;
         if ($header === null) {
-            return null;
+            return $cell;
         }
 
-        return $cell
-            ->addAttributes($column->headerAttributes)
-            ->content($header);
+        return $cell->content($header);
     }
 
     public function renderBody(ColumnInterface $column, Cell $cell, DataContext $context): Cell

--- a/src/GridView/GridView.php
+++ b/src/GridView/GridView.php
@@ -1037,9 +1037,14 @@ final class GridView extends BaseListView
         if ($this->isHeaderEnabled) {
             $tags = [];
             foreach ($columns as $i => $column) {
-                $cell = $renderers[$i]->renderHeader($column, new Cell($this->headerCellAttributes), $globalContext);
-                $tags[] = $cell === null
-                    ? Html::th('&nbsp;')->encode(false)
+                $headerCell = new Cell($this->headerCellAttributes);
+                /**
+                 * @psalm-suppress PossiblyNullReference The `??` operator puts its left operand into isset context,
+                 * so Psalm treats `$renderers[$i]` as possibly null.
+                 */
+                $cell = $renderers[$i]->renderHeader($column, $headerCell, $globalContext) ?? $headerCell;
+                $tags[] = $cell->isEmptyContent()
+                    ? Html::th('&nbsp;', $cell->getAttributes())->encode(false)
                     : Html::th(attributes: $cell->getAttributes())
                         ->content(...$cell->getContent())
                         ->encode($cell->shouldEncode())

--- a/tests/GridView/Column/CheckboxColumnTest.php
+++ b/tests/GridView/Column/CheckboxColumnTest.php
@@ -157,6 +157,24 @@ final class CheckboxColumnTest extends TestCase
         );
     }
 
+    public function testHeaderAttributesWithoutHeader(): void
+    {
+        $html = $this->createGridView([['id' => 1]])
+            ->headerCellAttributes(['class' => 'header-cell-class'])
+            ->columns(new CheckboxColumn(
+                headerAttributes: ['style' => 'width: 1%'],
+                multiple: false,
+            ))
+            ->render();
+
+        $this->assertStringContainsString(
+            <<<HTML
+            <th class="header-cell-class" style="width: 1%">&nbsp;</th>
+            HTML,
+            $html,
+        );
+    }
+
     public function testBodyAttributes(): void
     {
         $html = $this->createGridView([['id' => 1]])

--- a/tests/GridView/Column/DataColumnTest.php
+++ b/tests/GridView/Column/DataColumnTest.php
@@ -39,7 +39,7 @@ final class DataColumnTest extends TestCase
             <table>
             <thead>
             <tr>
-            <th></th>
+            <th>&nbsp;</th>
             </tr>
             </thead>
             <tbody>

--- a/tests/GridView/Column/RadioColumnTest.php
+++ b/tests/GridView/Column/RadioColumnTest.php
@@ -130,6 +130,25 @@ final class RadioColumnTest extends TestCase
         );
     }
 
+    public function testHeaderAttributesWithoutHeader(): void
+    {
+        $html = $this->createGridView([['id' => 1]])
+            ->headerCellAttributes(['class' => 'header-cell-class'])
+            ->columns(
+                new RadioColumn(
+                    headerAttributes: ['style' => 'width: 1%'],
+                ),
+            )
+            ->render();
+
+        $this->assertStringContainsString(
+            <<<HTML
+            <th class="header-cell-class" style="width: 1%">&nbsp;</th>
+            HTML,
+            $html,
+        );
+    }
+
     public function testBodyAttributes(): void
     {
         $html = $this->createGridView([['id' => 1]])

--- a/tests/GridView/GridViewTest.php
+++ b/tests/GridView/GridViewTest.php
@@ -33,6 +33,7 @@ use Yiisoft\Yii\DataView\Filter\Factory\IncorrectValueException;
 use Yiisoft\Yii\DataView\Filter\Widget\DropdownFilter;
 use Yiisoft\Yii\DataView\GridView\BodyRowContext;
 use Yiisoft\Yii\DataView\GridView\Column\Base\DataContext;
+use Yiisoft\Yii\DataView\GridView\Column\CheckboxColumn;
 use Yiisoft\Yii\DataView\GridView\Column\DataColumn;
 use Yiisoft\Yii\DataView\GridView\GridView;
 use Yiisoft\Yii\DataView\PageSize\SelectPageSize;
@@ -781,6 +782,29 @@ final class GridViewTest extends TestCase
             <tr>
             <th class="header-cell" data-sort="enabled">Id</th>
             <th class="header-cell" data-sort="enabled">Name</th>
+            </tr>
+            </thead>
+            HTML,
+            $html,
+        );
+    }
+
+    public function testHeaderCellAttributesWithoutColumnHeader(): void
+    {
+        $html = $this->createGridView([['id' => 1, 'name' => 'John']])
+            ->headerCellAttributes(['class' => 'text-center'])
+            ->columns(
+                new CheckboxColumn(headerAttributes: ['style' => 'width: 1%'], multiple: false),
+                new DataColumn('name'),
+            )
+            ->render();
+
+        $this->assertStringContainsString(
+            <<<HTML
+            <thead>
+            <tr>
+            <th class="text-center" style="width: 1%">&nbsp;</th>
+            <th class="text-center">Name</th>
             </tr>
             </thead>
             HTML,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
